### PR TITLE
[Concurrency] Adding `Sendable` conformance to types

### DIFF
--- a/Keyboard/Converter/ComposingText.swift
+++ b/Keyboard/Converter/ComposingText.swift
@@ -12,12 +12,12 @@
 /// のようになる。`
 /// カーソルのポジションもこのクラスが管理する。
 /// 設計方針として、inputStyleに関わる実装の違いは全てアップデート方法の違いとして吸収し、`input` / `delete` / `moveCursor` / `complete`時の違いとしては露出させないようにすることを目指した。
-struct ComposingText {
+struct ComposingText: Sendable {
     private(set) var convertTargetCursorPosition: Int = 0
     private(set) var input: [InputElement] = []
     private(set) var convertTarget: String = ""
 
-    struct InputElement {
+    struct InputElement: Sendable {
         var character: Character
         var inputStyle: InputStyle
     }

--- a/Keyboard/Converter/DicdataStore/DicdataElement.swift
+++ b/Keyboard/Converter/DicdataStore/DicdataElement.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct DicdataElement: Equatable, Hashable {
+struct DicdataElement: Equatable, Hashable, Sendable {
     static let BOSData = Self(word: "", ruby: "", cid: CIDData.BOS.cid, mid: MIDData.BOS.mid, value: 0, adjust: 0)
     static let EOSData = Self(word: "", ruby: "", cid: CIDData.EOS.cid, mid: MIDData.EOS.mid, value: 0, adjust: 0)
 

--- a/Keyboard/Converter/DicdataStore/LearningMemory.swift
+++ b/Keyboard/Converter/DicdataStore/LearningMemory.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-private struct MetadataElement: CustomDebugStringConvertible {
+private struct MetadataElement: CustomDebugStringConvertible, Sendable {
     init(day: UInt16, count: UInt8) {
         self.lastUsedDay = day
         self.lastUpdatedDay = day
@@ -25,7 +25,7 @@ private struct MetadataElement: CustomDebugStringConvertible {
 }
 
 /// 長期記憶用の構造体
-struct LongTermLearningMemory {
+struct LongTermLearningMemory: Sendable {
     static let directoryURL = (try? FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)) ?? FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: SharedStore.appGroupKey)!
     private static var loudsFileURL: URL {
         directoryURL.appendingPathComponent("memory.louds", isDirectory: false)
@@ -309,8 +309,8 @@ struct LongTermLearningMemory {
 }
 
 /// 一時記憶用のデータなので、複雑な形状にしない。
-struct TemporalLearningMemoryTrie {
-    struct Node {
+struct TemporalLearningMemoryTrie: Sendable {
+    struct Node: Sendable {
         var dataIndices: [Int] = []      // loudstxt3の中のデータのインデックスリスト
         var children: [UInt8: Int] = [:] // characterのIDからインデックスへのマッピング
     }

--- a/Keyboard/Converter/RegisteredNodeProtocol.swift
+++ b/Keyboard/Converter/RegisteredNodeProtocol.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol RegisteredNodeProtocol {
+protocol RegisteredNodeProtocol: Sendable {
     var data: DicdataElement {get}
     var prev: (any RegisteredNodeProtocol)? {get}
     var totalValue: PValue {get}
@@ -16,7 +16,7 @@ protocol RegisteredNodeProtocol {
     var convertTargetLength: Int {get}
 }
 
-struct RegisteredNode: RegisteredNodeProtocol {
+struct RegisteredNode: RegisteredNodeProtocol, Sendable {
     let data: DicdataElement
     let prev: (any RegisteredNodeProtocol)?
     let totalValue: PValue

--- a/Shared/Converter/TemplateData.swift
+++ b/Shared/Converter/TemplateData.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-struct TemplateData: Codable {
+struct TemplateData: Codable, Sendable {
     var name: String
-    var literal: TemplateLiteralProtocol
+    var literal: any TemplateLiteralProtocol
     var type: TemplateLiteralType
 
     private enum CodingKeys: String, CodingKey {
@@ -70,13 +70,13 @@ struct TemplateData: Codable {
     }
 }
 
-protocol TemplateLiteralProtocol {
+protocol TemplateLiteralProtocol: Sendable {
     func export() -> String
 
     func previewString() -> String
 }
 
-enum TemplateLiteralType {
+enum TemplateLiteralType: Sendable {
     case date
     case random
 }
@@ -158,12 +158,13 @@ struct RandomTemplateLiteral: TemplateLiteralProtocol, Equatable {
         lhs.value == rhs.value
     }
 
-    enum ValueType: String {
+    enum ValueType: String, Sendable {
         case int
         case double
         case string
     }
-    enum Value: Equatable {
+
+    enum Value: Equatable, Sendable {
         case int(from: Int, to: Int)
         case double(from: Double, to: Double)
         case string([String])

--- a/Shared/KeyboardSetting/LanguageLayoutKeyboardSetting.swift
+++ b/Shared/KeyboardSetting/LanguageLayoutKeyboardSetting.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftUI
 
-enum LanguageLayout {
+enum LanguageLayout: Sendable {
     case flick
     case qwerty
     case custard(String)

--- a/Shared/KeyboardSetting/LearningTypeSetting.swift
+++ b/Shared/KeyboardSetting/LearningTypeSetting.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftUI
 
-enum LearningType: Int, CaseIterable {
+enum LearningType: Int, CaseIterable: Sendable {
     case inputAndOutput = 0
     case onlyOutput = 1
     case nothing = 2

--- a/Shared/KeyboardSetting/MemoryResetCondition.swift
+++ b/Shared/KeyboardSetting/MemoryResetCondition.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum MemoryResetCondition: Int, Savable {
+enum MemoryResetCondition: Int, Savable, Sendable {
     typealias SaveValue = String
     case none = 0
     case need = 1

--- a/Shared/KeyboardSetting/PreferedLanguageKeyboardSetting.swift
+++ b/Shared/KeyboardSetting/PreferedLanguageKeyboardSetting.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftUI
 
-struct PreferredLanguage: Codable, Hashable {
+struct PreferredLanguage: Codable, Hashable, Sendable {
     var first: KeyboardLanguage
     var second: KeyboardLanguage?
 }

--- a/Shared/KeyboardSetting/QwertyCustomKeySetting.swift
+++ b/Shared/KeyboardSetting/QwertyCustomKeySetting.swift
@@ -9,12 +9,12 @@
 import CustardKit
 import SwiftUI
 
-private struct _QwertyVariationKey: Codable {
+private struct _QwertyVariationKey: Codable, Sendable {
     var name: String
     var input: String
 }
 
-private struct _QwertyCustomKey: Codable {
+private struct _QwertyCustomKey: Codable, Sendable {
     var name: String
     var longpress: [String]
     var input: String
@@ -45,6 +45,7 @@ private struct _QwertyCustomKey: Codable {
     }
 }
 
+// TODO: Adding `Sendable` Conformance to this type after CustardKit supports `Sendable`.
 struct QwertyVariationKey: Codable, Equatable {
     internal init(name: String, actions: [CodableActionData]) {
         self.name = name
@@ -55,12 +56,14 @@ struct QwertyVariationKey: Codable, Equatable {
     var actions: [CodableActionData]
 }
 
+// TODO: Adding `Sendable` Conformance to this type after CustardKit supports `Sendable`.
 struct QwertyCustomKey: Codable, Equatable {
     var name: String
     var actions: [CodableActionData]
     var longpresses: [QwertyVariationKey]
 }
 
+// TODO: Adding `Sendable` Conformance to this type after CustardKit supports `Sendable`.
 private struct QwertyCustomKeysArray: Codable {
     // let list: [_QwertyCustomKey]
     let keys: [QwertyCustomKey]
@@ -93,6 +96,7 @@ private struct QwertyCustomKeysArray: Codable {
     }
 }
 
+// TODO: Adding `Sendable` Conformance to this type after CustardKit supports `Sendable`.
 struct QwertyCustomKeysValue: Savable, Equatable {
     typealias SaveValue = Data
     static let defaultValue = QwertyCustomKeysValue(keys: [

--- a/Shared/KeyboardView/States.swift
+++ b/Shared/KeyboardView/States.swift
@@ -8,21 +8,21 @@
 
 import enum UIKit.UIReturnKeyType
 
-enum KeyboardLayout: String, CaseIterable {
+enum KeyboardLayout: String, CaseIterable, Sendable {
     /// フリック入力式のレイアウトで表示するスタイル
     case flick = "flick"
     /// qwerty入力式のレイアウトで表示するスタイル
     case qwerty = "roman"
 }
 
-enum InputStyle: String {
+enum InputStyle: String, Sendable {
     /// 入力された文字を直接入力するスタイル
     case direct = "direct"
     /// ローマ字日本語入力とするスタイル
     case roman2kana = "roman"
 }
 
-enum KeyboardLanguage: String, Codable, Equatable {
+enum KeyboardLanguage: String, Codable, Equatable, Sendable {
     case en_US
     case ja_JP
     case el_GR
@@ -42,24 +42,24 @@ enum KeyboardLanguage: String, Codable, Equatable {
     }
 }
 
-enum ResizingState {
+enum ResizingState: Sendable {
     case fullwidth // 両手モードの利用
     case onehanded // 片手モードの利用
     case resizing  // 編集モード
 }
 
-enum KeyboardOrientation {
+enum KeyboardOrientation: Sendable {
     case vertical       // width<height
     case horizontal     // height<width
 }
 
-enum EnterKeyState {
+enum EnterKeyState: Sendable {
     case complete   // 決定
     case `return`(UIReturnKeyType)   // 改行
     case edit       // 編集
 }
 
-enum BarState {
+enum BarState: Sendable {
     case none   // なし
     case tab    // タブバー
     case cursor // カーソルバー

--- a/Shared/Message.swift
+++ b/Shared/Message.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum MessageIdentifier: String, Hashable, CaseIterable {
+enum MessageIdentifier: String, Hashable, CaseIterable, Sendable {
     case mock = "mock_alert_2022_09_16_03"
     case iOS15_4_new_emoji = "iOS_15_4_new_emoji"                    // MARK: frozen
     case ver1_9_user_dictionary_update = "ver1_9_user_dictionary_update_release" // MARK: frozen

--- a/Shared/SwiftLanuage/AppVersion.swift
+++ b/Shared/SwiftLanuage/AppVersion.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct AppVersion: Codable, Equatable, Comparable, Hashable, LosslessStringConvertible, CustomStringConvertible {
+struct AppVersion: Codable, Equatable, Comparable, Hashable, LosslessStringConvertible, CustomStringConvertible, Sendable {
 
     private enum ParseError: Error {
         case nonIntegerValue


### PR DESCRIPTION
While it will be difficult steps to support Swift Concurrency, it is easy to make types `Sendable`. In this PR, I make types conforming `Sendable` as far as possible.