### PR TITLE
[Performance Tuning] CharIDへの変換を削減し、5%程度の高速化を達成

### DIFF
--- a/Keyboard/Converter/DicdataStore/LearningMemory.swift
+++ b/Keyboard/Converter/DicdataStore/LearningMemory.swift
@@ -500,34 +500,25 @@ final class LearningManager {
         }
     }
 
-    func temporaryPerfectMatch(key: some StringProtocol) -> [DicdataElement] {
+    func temporaryPerfectMatch(charIDs: [UInt8]) -> [DicdataElement] {
         if !options.learningType.needUsingMemory {
             return []
         }
-        guard let chars = Self.keyToChars(key) else {
-            return []
-        }
-        return self.temporaryMemory.perfectMatch(chars: chars)
+        return self.temporaryMemory.perfectMatch(chars: charIDs)
     }
 
-    func temporaryThroughMatch(key: some StringProtocol, depth: Range<Int>) -> [DicdataElement] {
+    func temporaryThroughMatch(charIDs: [UInt8], depth: Range<Int>) -> [DicdataElement] {
         if !options.learningType.needUsingMemory {
             return []
         }
-        guard let chars = Self.keyToChars(key) else {
-            return []
-        }
-        return self.temporaryMemory.throughMatch(chars: chars, depth: depth)
+        return self.temporaryMemory.throughMatch(chars: charIDs, depth: depth)
     }
 
-    func temporaryPrefixMatch(key: some StringProtocol) -> [DicdataElement] {
+    func temporaryPrefixMatch(charIDs: [UInt8]) -> [DicdataElement] {
         if !options.learningType.needUsingMemory {
             return []
         }
-        guard let chars = Self.keyToChars(key) else {
-            return []
-        }
-        return self.temporaryMemory.prefixMatch(chars: chars)
+        return self.temporaryMemory.prefixMatch(chars: charIDs)
     }
 
     func update(data: [DicdataElement]) {

--- a/Keyboard/Converter/Kana2Kanji/getPrediction.swift
+++ b/Keyboard/Converter/Kana2Kanji/getPrediction.swift
@@ -50,7 +50,7 @@ extension Kana2Kanji {
         let dicdata: [DicdataElement]
         switch mainInputStyle {
         case .direct:
-            dicdata = self.dicdataStore.getPredictionLOUDSDicdata(head: lastRuby)
+            dicdata = self.dicdataStore.getPredictionLOUDSDicdata(key: lastRuby)
         case .roman2kana:
             let roman = lastRuby.suffix(while: {String($0).onlyRomanAlphabet})
             if !roman.isEmpty {
@@ -61,10 +61,10 @@ extension Kana2Kanji {
                 }
                 let possibleNexts: [Substring] = DicdataStore.possibleNexts[String(roman), default: []].map {ruby + $0}
                 debug("getPredicitonCandidates", lastRuby, ruby, roman, possibleNexts, prepart, lastRubyCount)
-                dicdata = possibleNexts.flatMap { self.dicdataStore.getPredictionLOUDSDicdata(head: $0) }
+                dicdata = possibleNexts.flatMap { self.dicdataStore.getPredictionLOUDSDicdata(key: $0) }
             } else {
                 debug("getPredicitonCandidates", lastRuby, roman)
-                dicdata = self.dicdataStore.getPredictionLOUDSDicdata(head: lastRuby)
+                dicdata = self.dicdataStore.getPredictionLOUDSDicdata(key: lastRuby)
             }
         }
 


### PR DESCRIPTION
#4 の一環で、CharIDへの変換を削減した。結果として5%程度の高速化が達成できた。

`testFullConversion`のベンチマークとしては
* before
  * `getLOUDSDataInRange`が全体の92%
* after
  * `getLOUDSDataInRange`が全体の86.5%

という感じ。
特に、keyToCharsの呼び出しはほぼゼロまで抑えられるようになった。