### PR TITLE
[Fix] marked text を有効にしている場合に、一部の文字入力でカーソル位置がおかしくなる問題を修正

### DIFF
--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -101,7 +101,10 @@ final class DisplayedTextManager {
     /// MarkedTextを更新する関数
     /// この関数自体はisMarkedTextEnabledのチェックを行わない。
     func updateMarkedText() {
-        self.proxy.setMarkedText(self.displayedText, selectedRange: NSRange(location: self.displayedTextCursorPosition, length: 0))
+        self.proxy.setMarkedText(
+            self.displayedText,
+            selectedRange: NSRange(location: self.displayedText.prefix(self.displayedTextCursorPosition).utf16.count, length: 0)
+        )
     }
 
     func insertText(_ text: String, shouldSimplyInsert: Bool = false) {


### PR DESCRIPTION
Fix #32 