### PR TITLE
[Experimental] ChatGPTをキーボード上で動かす

### DIFF
--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -112,11 +112,11 @@ final class DisplayedTextManager {
     /// MarkedTextを更新する関数
     /// この関数自体はisMarkedTextEnabledのチェックを行わない。
     func updateMarkedText() {
-        let text = self.displayedLiveConversionText ?? self.displayedText
-        let cursorPosition = self.displayedLiveConversionText.map(NSString.init(string:))?.length ?? NSString(string: String(self.displayedText.prefix(self.displayedTextCursorPosition))).length
+        let text = self.displayedLiveConversionText ?? self.composingText.convertTarget
+        let cursorPosition = self.displayedLiveConversionText.map(NSString.init(string:))?.length ?? NSString(string: String(self.composingText.convertTarget.prefix(self.composingText.convertTargetCursorPosition))).length
         self.proxy.setMarkedText(text, selectedRange: NSRange(location: cursorPosition, length: 0))
     }
-    
+
     func insertText(_ text: String) {
         guard !text.isEmpty else {
             return
@@ -141,7 +141,7 @@ final class DisplayedTextManager {
         case deleteTooMuch
     }
 
-    func moveCursor(count: Int, isComposing: Bool = true) throws {
+    func moveCursor(count: Int, isComposing: Bool = true) {
         guard count != 0 else {
             return
         }
@@ -310,41 +310,6 @@ final class DisplayedTextManager {
             self.moveCursor(count: composingText.convertTargetCursorPosition - cursorPosition)
             self.composingText = composingText
             self.displayedLiveConversionText = nil
-        }
-    }
-
-    /// ライブ変換結果の表示を止める
-    func dismissLiveConversionText() {
-        if isMarkedTextEnabled {
-            self.displayedLiveConversionText = nil
-            self.updateMarkedText()
-        } else {
-            let oldDisplayedText = self.displayedLiveConversionText ?? self.displayedText
-            let commonPrefix = oldDisplayedText.commonPrefix(with: self.displayedText)
-            let delete = oldDisplayedText.count - commonPrefix.count
-            let input = self.displayedText.suffix(self.displayedText.count - commonPrefix.count)
-            self.rawDeleteBackward(count: delete)
-            self.proxy.insertText(String(input))
-            self.displayedLiveConversionText = nil
-        }
-    }
-
-    /// ライブ変換結果を更新する
-    func updateLiveConversionText(liveConversionText: String) {
-        if liveConversionText.isEmpty {
-            self.dismissLiveConversionText()
-            return
-        }
-        let oldDisplayedText = self.displayedLiveConversionText ?? self.displayedText
-        self.displayedLiveConversionText = liveConversionText
-        if isMarkedTextEnabled {
-            self.updateMarkedText()
-        } else {
-            let commonPrefix = oldDisplayedText.commonPrefix(with: liveConversionText)
-            let delete = oldDisplayedText.count - commonPrefix.count
-            let input = liveConversionText.suffix(liveConversionText.count - commonPrefix.count)
-            self.rawDeleteBackward(count: delete)
-            self.proxy.insertText(String(input))
         }
     }
 

--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -280,33 +280,32 @@ final class DisplayedTextManager {
         return false
     }
 
-    func updateComposingText(composingText: ComposingText, completedPrefix: String, isSelected: inout Bool) {
+    func updateComposingText(composingText: ComposingText, completedPrefix: String, isSelected: Bool) {
         if isMarkedTextEnabled {
             self.insertText(completedPrefix)
             self.composingText = composingText
-            self.updateMarkedText()
-            isSelected = false
             self.displayedLiveConversionText = nil
+            self.updateMarkedText()
         } else {
             // (例１): [あいし|てる] (「あい」を確定)
             // (削除): [|てる]
             // (挿入): 愛[|てる]
             // (挿入): 愛[し|てる]
             // (移動): 愛[し|てる]
+            //
             // (例２): [あい|してる] (「あい」を確定)
             // (削除): [|してる]
             // (挿入): 愛[|してる]
             // (挿入): 愛[|してる]
             // (移動): 愛[してる|]
+            // 選択中でない場合、削除する
             if !isSelected {
                 let count = self.displayedLiveConversionText?.count ?? self.composingText.convertTargetCursorPosition
                 try? self.deleteBackward(count: count)
-                isSelected = false
             }
-            self.insertText(completedPrefix)
             let delta = self.composingText.convertTarget.count - composingText.convertTarget.count
             let cursorPosition = self.composingText.convertTargetCursorPosition - delta
-            self.insertText(String(self.composingText.convertTargetBeforeCursor.suffix(cursorPosition)))
+            self.insertText(completedPrefix + String(self.composingText.convertTargetBeforeCursor.suffix(cursorPosition)))
             self.moveCursor(count: composingText.convertTargetCursorPosition - cursorPosition)
             self.composingText = composingText
             self.displayedLiveConversionText = nil

--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -26,22 +26,34 @@ final class DisplayedTextManager {
     /// marked textの有効化状態
     private(set) var isMarkedTextEnabled: Bool
     private var proxy: UITextDocumentProxy! {
-        if let inKeyboardProxy {
-            return inKeyboardProxy
+        switch preferredTextProxy {
+        case .main: return displayedTextProxy
+        case .ikTextField: return ikTextFieldProxy ?? displayedTextProxy
         }
-        return displayedTextProxy
     }
+
+    private var preferredTextProxy: AnyTextDocumentProxy.Preference = .main
     /// キーボード外のテキストを扱う`UITextDocumentProxy`
     private var displayedTextProxy: UITextDocumentProxy!
     /// キーボード内テキストフィールドの`UITextDocumentProxy`
-    private var inKeyboardProxy: UITextDocumentProxy?
+    private var ikTextFieldProxy: UITextDocumentProxy?
 
-    func setTextDocumentProxy(_ proxy: UITextDocumentProxy!) {
-        self.displayedTextProxy = proxy
+    func setTextDocumentProxy(_ proxy: AnyTextDocumentProxy) {
+        switch proxy {
+        case let .mainProxy(proxy):
+            self.displayedTextProxy = proxy
+        case let .ikTextFieldProxy(proxy):
+            self.ikTextFieldProxy = proxy
+            if proxy == nil {
+                self.preferredTextProxy = .main
+            }
+        case let .preference(preference):
+            self.preferredTextProxy = preference
+        }
     }
 
-    func setInKeyboardProxy(_ proxy: UITextDocumentProxy?) {
-        self.inKeyboardProxy = proxy
+    var shouldSkipMarkedTextChange: Bool {
+        self.isMarkedTextEnabled && preferredTextProxy == .ikTextField && ikTextFieldProxy != nil
     }
 
     var documentContextAfterInput: String? {

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -237,12 +237,13 @@ final class InputManager {
 
         self.composingText.insertAtCursorPosition(text, inputStyle: VariableStates.shared.inputStyle)
         debug("Input Manager input:", composingText)
-        self.displayedTextManager.updateComposingText(composingText: self.composingText)
-
-        VariableStates.shared.setEnterKeyState(.complete)
-
         if requireSetResult {
+            // 入力を反映する
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
+            // 変換を実施する
             setResult()
+            // キーの種類を変更
+            VariableStates.shared.setEnterKeyState(.complete)
         }
     }
 
@@ -261,15 +262,15 @@ final class InputManager {
 
         self.composingText.deleteForwardFromCursorPosition(count: count)
         debug("Input Manager deleteForward: ", composingText)
-        // 削除を実行する
-        self.displayedTextManager.updateComposingText(composingText: self.composingText)
 
         if requireSetResult {
-            setResult()
-        }
-
-        if self.composingText.isEmpty {
-            VariableStates.shared.setEnterKeyState(.return)
+            // 削除を反映する
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
+            // 変換を実施する
+            self.setResult()
+            if self.composingText.isEmpty {
+                VariableStates.shared.setEnterKeyState(.return)
+            }
         }
     }
 
@@ -302,16 +303,14 @@ final class InputManager {
         self.composingText.deleteBackwardFromCursorPosition(count: convertTargetCount)
         debug("Input Manager deleteBackword: ", composingText)
 
-        // 削除を実行する
-        // 消し過ぎの可能性は考えなくて大丈夫な状況
-        self.displayedTextManager.updateComposingText(composingText: self.composingText)
-
         if requireSetResult {
-            setResult()
-        }
-
-        if self.composingText.isEmpty {
-            VariableStates.shared.setEnterKeyState(.return)
+            // 削除を反映する
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
+            // 変換を実施する
+            self.setResult()
+            if self.composingText.isEmpty {
+                VariableStates.shared.setEnterKeyState(.return)
+            }
         }
     }
 
@@ -325,6 +324,7 @@ final class InputManager {
         }
         // 入力中の場合
         if !self.composingText.isEmpty {
+            // TODO: Check implementation of `requireSetResult`
             // カーソルより前を全部消す
             self.composingText.deleteBackwardFromCursorPosition(count: self.composingText.convertTargetCursorPosition)
             self.displayedTextManager.updateComposingText(composingText: composingText)
@@ -368,6 +368,7 @@ final class InputManager {
         }
         // 入力中の場合
         if !self.composingText.isEmpty {
+            // TODO: Check implementation of `requireSetResult`
             // count文字消せるのは自明なので、返り値は無視できる
             self.composingText.deleteForwardFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
             self.displayedTextManager.updateComposingText(composingText: self.composingText)

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -103,12 +103,8 @@ final class InputManager {
         self.kanaKanjiConverter.sendToDicdataStore(data)
     }
 
-    func setTextDocumentProxy(_ proxy: UITextDocumentProxy) {
+    func setTextDocumentProxy(_ proxy: AnyTextDocumentProxy) {
         self.displayedTextManager.setTextDocumentProxy(proxy)
-    }
-
-    func setInKeyboardProxy(_ proxy: UITextDocumentProxy?) {
-        self.displayedTextManager.setInKeyboardProxy(proxy)
     }
 
     func setUpdateResult(_ updateResult: @escaping ([Candidate]) -> Void) {
@@ -127,7 +123,7 @@ final class InputManager {
     func complete(candidate: Candidate) {
         self.updateLog(candidate: candidate)
         self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
-        if self.displayedTextManager.isMarkedTextEnabled {
+        if self.displayedTextManager.shouldSkipMarkedTextChange {
             self.afterAdjusted = true
         }
         self.displayedTextManager.updateComposingText(composingText: self.composingText, completedPrefix: candidate.text, isSelected: self.isSelected)
@@ -729,6 +725,9 @@ final class InputManager {
 
         // 表示を更新する
         if !self.isSelected {
+            if self.displayedTextManager.shouldSkipMarkedTextChange {
+                self.afterAdjusted = true
+            }
             if liveConversionEnabled {
                 let liveConversionText = self.liveConversionManager.updateWithNewResults(results, firstClauseResults: firstClauseResults, convertTargetCursorPosition: inputData.convertTargetCursorPosition, convertTarget: inputData.convertTarget)
                 self.displayedTextManager.updateComposingText(composingText: self.composingText, newLiveConversionText: liveConversionText)

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -127,7 +127,8 @@ final class InputManager {
     func complete(candidate: Candidate) {
         self.updateLog(candidate: candidate)
         self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
-        self.displayedTextManager.updateComposingText(composingText: self.composingText, completedPrefix: candidate.text, isSelected: &self.isSelected)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText, completedPrefix: candidate.text, isSelected: self.isSelected)
+        self.isSelected = false
 
         self.kanaKanjiConverter.updateLearningData(candidate)
         guard !self.composingText.isEmpty else {

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -131,13 +131,11 @@ final class InputManager {
             // 消しすぎることはないのでエラーは無視できる
             try? self.displayedTextManager.deleteBackward(count: self.displayedTextManager.displayedTextCursorPosition)
         }
-        self.isSelected = false
 
-        debug("complete:", candidate, composingText)
+        self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText, completedPrefix: candidate.text, isSelected: &self.isSelected)
+
         self.kanaKanjiConverter.updateLearningData(candidate)
-        self.composingText.complete(correspondingCount: candidate.correspondingCount)
-        self.displayedTextManager.insertText(candidate.text, shouldSimplyInsert: true)
-        self.displayedTextManager.insertText(String(self.composingText.convertTargetBeforeCursor))
         guard !self.composingText.isEmpty else {
             self.clear()
             return
@@ -146,14 +144,6 @@ final class InputManager {
 
         if liveConversionEnabled {
             self.liveConversionManager.updateAfterFirstClauseCompletion()
-        }
-        // 左端にある場合はカーソルを右端に持っていく
-        if self.composingText.isAtStartIndex {
-            _ = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTarget.count)
-            // 入力の直後、documentContextAfterInputは間違っていることがあるため、ここではoffsetをcomposingTextから直接計算する。
-            let offset = self.composingText.convertTarget.utf16.count
-            self.displayedTextManager.unsafeMoveCursor(unsafeCount: offset)
-            self.afterAdjusted = true
         }
         self.setResult()
     }
@@ -183,13 +173,13 @@ final class InputManager {
             candidate = _candidate
         } else {
             candidate = Candidate(
-                text: self.displayedTextManager.displayedText,
+                text: self.composingText.convertTarget,
                 value: -18,
                 correspondingCount: self.composingText.input.count,
                 lastMid: MIDData.一般.mid,
                 data: [
                     DicdataElement(
-                        word: self.displayedTextManager.displayedText,
+                        word: self.composingText.convertTarget,
                         ruby: self.composingText.convertTarget.toKatakana(),
                         cid: CIDData.固有名詞.cid,
                         mid: MIDData.一般.mid,
@@ -203,7 +193,7 @@ final class InputManager {
         candidate.withActions(actions)
         candidate.parseTemplate()
         self.kanaKanjiConverter.updateLearningData(candidate)
-        self.composingText.complete(correspondingCount: candidate.correspondingCount)
+        self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
         self.displayedTextManager.enter()
         self.clear()
         return actions
@@ -223,10 +213,10 @@ final class InputManager {
             // composingTextをクリアする
             self.composingText.clear()
             // キーボードの状態と無関係にdirectに設定し、入力をそのまま持たせる
-            _ = self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
+            self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
 
             // 実際に入力する
-            self.displayedTextManager.insertText(text)
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
             setResult()
 
             VariableStates.shared.setEnterKeyState(.complete)
@@ -235,25 +225,25 @@ final class InputManager {
 
         if text == "\n"{
             _ = self.enter()
-            self.displayedTextManager.insertText(text, shouldSimplyInsert: true)
+            self.displayedTextManager.insertText(text)
             return
         }
         // スペースだった場合
         if text == " " || text == "　" || text == "\t" || text == "\0"{
             _ = self.enter()
-            self.displayedTextManager.insertText(text, shouldSimplyInsert: true)
+            self.displayedTextManager.insertText(text)
             return
         }
 
         if VariableStates.shared.keyboardLanguage == .none {
             _ = self.enter()
-            self.displayedTextManager.insertText(text, shouldSimplyInsert: true)
+            self.displayedTextManager.insertText(text)
             return
         }
 
-        let operation = self.composingText.insertAtCursorPosition(text, inputStyle: VariableStates.shared.inputStyle)
-        debug("Input Manager input: ", composingText)
-        self.displayedTextManager.replace(count: operation.delete, with: operation.input)
+        self.composingText.insertAtCursorPosition(text, inputStyle: VariableStates.shared.inputStyle)
+        debug("Input Manager input:", composingText)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText)
 
         VariableStates.shared.setEnterKeyState(.complete)
 
@@ -271,16 +261,14 @@ final class InputManager {
 
         guard !self.composingText.isEmpty else {
             // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteForward(count: count, isComposing: false)
+            try? self.displayedTextManager.deleteForward(count: count)
             return
         }
 
-        let operation = self.composingText.deleteForwardFromCursorPosition(count: count)
+        self.composingText.deleteForwardFromCursorPosition(count: count)
         debug("Input Manager deleteForward: ", composingText)
         // 削除を実行する
-        // 消し過ぎの可能性は考えなくて大丈夫な状況
-        // ただしoperation.deleteは負の値である
-        try? self.displayedTextManager.deleteForward(count: -operation.delete)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText)
 
         if requireSetResult {
             setResult()
@@ -313,16 +301,16 @@ final class InputManager {
         }
         guard !self.composingText.isEmpty else {
             // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteBackward(count: convertTargetCount, isComposing: false)
+            try? self.displayedTextManager.deleteBackward(count: convertTargetCount)
             return
         }
 
-        let operation = self.composingText.deleteBackwardFromCursorPosition(count: convertTargetCount)
+        self.composingText.deleteBackwardFromCursorPosition(count: convertTargetCount)
         debug("Input Manager deleteBackword: ", composingText)
 
         // 削除を実行する
         // 消し過ぎの可能性は考えなくて大丈夫な状況
-        try? self.displayedTextManager.deleteBackward(count: operation.delete)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText)
 
         if requireSetResult {
             setResult()
@@ -344,12 +332,8 @@ final class InputManager {
         // 入力中の場合
         if !self.composingText.isEmpty {
             // カーソルより前を全部消す
-            // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteBackward(count: self.displayedTextManager.displayedTextCursorPosition)
-            // カーソルより前を全部消す
-            // 戻り値は無視できる
-            _ = self.composingText.deleteBackwardFromCursorPosition(count: self.composingText.convertTargetCursorPosition)
-
+            self.composingText.deleteBackwardFromCursorPosition(count: self.composingText.convertTargetCursorPosition)
+            self.displayedTextManager.updateComposingText(composingText: composingText)
             // カーソルを先頭に移動する
             self.moveCursor(count: self.composingText.convertTarget.count)
             // 文字がもうなかった場合
@@ -369,13 +353,13 @@ final class InputManager {
                 break
             } else {
                 // 消し過ぎの可能性は考えなくて大丈夫な状況
-                try? self.displayedTextManager.deleteBackward(count: 1, isComposing: false)
+                try? self.displayedTextManager.deleteBackward(count: 1)
                 deletedCount += 1
             }
         }
         if deletedCount == 0 {
             // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteBackward(count: 1, isComposing: false)
+            try? self.displayedTextManager.deleteBackward(count: 1)
         }
     }
 
@@ -390,10 +374,9 @@ final class InputManager {
         }
         // 入力中の場合
         if !self.composingText.isEmpty {
-            // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteForward(count: self.displayedTextManager.displayedText.count - self.displayedTextManager.displayedTextCursorPosition)
             // count文字消せるのは自明なので、返り値は無視できる
-            _ = self.composingText.deleteForwardFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
+            self.composingText.deleteForwardFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
             // 文字がもうなかった場合
             if self.composingText.isEmpty {
                 clear()
@@ -408,13 +391,13 @@ final class InputManager {
                 break
             } else {
                 // 消し過ぎの可能性は考えなくて大丈夫な状況
-                try? self.displayedTextManager.deleteForward(count: 1, isComposing: false)
+                try? self.displayedTextManager.deleteForward(count: 1)
                 deletedCount += 1
             }
         }
         if deletedCount == 0 {
             // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteForward(count: 1, isComposing: false)
+            try? self.displayedTextManager.deleteForward(count: 1)
         }
     }
 
@@ -424,7 +407,7 @@ final class InputManager {
         if isSelected {
             let count = self.composingText.convertTarget.count
             deselect()
-            try? self.displayedTextManager.moveCursor(count: count, isComposing: false)
+            self.displayedTextManager.moveCursor(count: count)
             if requireSetResult {
                 setResult()
             }
@@ -432,13 +415,12 @@ final class InputManager {
         }
         // 入力中の場合
         if !composingText.isEmpty {
-            let operation = self.composingText.moveCursorFromCursorPosition(count: -self.composingText.convertTargetCursorPosition)
-            do {
-                try self.displayedTextManager.moveCursor(count: operation.cursor)
-            } catch {
-                self.clear()
+            if self.liveConversionEnabled {
+                _ = self.enter()
                 return
             }
+            _ = self.composingText.moveCursorFromCursorPosition(count: -self.composingText.convertTargetCursorPosition)
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
             if requireSetResult {
                 setResult()
             }
@@ -450,14 +432,12 @@ final class InputManager {
             if nexts.contains(last) {
                 break
             } else {
-                // ここを実行する場合変換中ではないので例外は無視できる
-                try? self.displayedTextManager.moveCursor(count: -1)
+                self.displayedTextManager.moveCursor(count: -1)
                 movedCount += 1
             }
         }
         if movedCount == 0 {
-            // ここを実行する場合変換中ではないので例外は無視できる
-            try? self.displayedTextManager.moveCursor(count: -1)
+            self.displayedTextManager.moveCursor(count: -1)
         }
     }
 
@@ -466,7 +446,7 @@ final class InputManager {
         // 選択状態では最も右にカーソルを移動
         if isSelected {
             deselect()
-            try? self.displayedTextManager.moveCursor(count: 1, isComposing: false)
+            self.displayedTextManager.moveCursor(count: 1)
             if requireSetResult {
                 setResult()
             }
@@ -474,13 +454,12 @@ final class InputManager {
         }
         // 入力中の場合
         if !composingText.isEmpty {
-            let operation = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
-            do {
-                try self.displayedTextManager.moveCursor(count: operation.cursor)
-            } catch {
-                self.clear()
+            if self.liveConversionEnabled {
+                _ = self.enter()
                 return
             }
+            _ = self.composingText.moveCursorFromCursorPosition(count: self.composingText.convertTarget.count - self.composingText.convertTargetCursorPosition)
+            self.displayedTextManager.updateComposingText(composingText: self.composingText)
             if requireSetResult {
                 setResult()
             }
@@ -492,14 +471,12 @@ final class InputManager {
             if nexts.contains(first) {
                 break
             } else {
-                // ここを実行する場合変換中ではないので例外は無視できる
-                try? self.displayedTextManager.moveCursor(count: 1)
+                self.displayedTextManager.moveCursor(count: 1)
                 movedCount += 1
             }
         }
         if movedCount == 0 {
-            // ここを実行する場合変換中ではないので例外は無視できる
-            try? self.displayedTextManager.moveCursor(count: 1)
+            self.displayedTextManager.moveCursor(count: 1)
         }
     }
 
@@ -581,7 +558,7 @@ final class InputManager {
             let leftside = displayedTextManager.documentContextBeforeInput ?? ""
             for count in (counts.min...counts.max).reversed() where count <= leftside.count {
                 if let replace = table[String(leftside.suffix(count))] {
-                    self.displayedTextManager.replace(count: count, with: replace, isComposing: false)
+                    self.displayedTextManager.replace(count: count, with: replace)
                     break
                 }
             }
@@ -617,18 +594,18 @@ final class InputManager {
         afterAdjusted = true
         // 入力中の文字が空の場合は普通に動かす
         if composingText.isEmpty {
-            // この場合は無視できる
-            try? self.displayedTextManager.moveCursor(count: count, isComposing: false)
+            self.displayedTextManager.moveCursor(count: count)
             return
         }
+        if self.liveConversionEnabled {
+            _ = self.enter()
+            return
+        }
+
         debug("Input Manager moveCursor:", composingText, count)
 
-        let operation = self.composingText.moveCursorFromCursorPosition(count: count)
-        do {
-            try self.displayedTextManager.moveCursor(count: operation.cursor)
-        } catch {
-            _ = self.enter()
-        }
+        _ = self.composingText.moveCursorFromCursorPosition(count: count)
+        self.displayedTextManager.updateComposingText(composingText: self.composingText)
         if count != 0 && requireSetResult {
             setResult()
         }
@@ -643,15 +620,14 @@ final class InputManager {
             return
         }
         let operation = composingText.moveCursorFromCursorPosition(count: count)
-        let afterAdjusted = self.displayedTextManager.setMovedCursor(movedCount: count, composingTextOperation: operation)
-        self.afterAdjusted = afterAdjusted
+        self.afterAdjusted = self.displayedTextManager.updateComposingText(composingText: self.composingText, userMovedCount: count, composingTextOperation: operation)
         setResult()
     }
 
     // ユーザがキーボードを経由せずペーストした場合の処理
     func userPastedText(text: String) {
         // 入力された分を反映する
-        _ = self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
+        self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
 
         isSelected = false
         setResult()
@@ -674,7 +650,7 @@ final class InputManager {
     // ユーザが選択領域で文字を入力した場合
     func userReplacedSelectedText(text: String) {
         // 新たな入力を反映
-        _ = self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
+        self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
 
         isSelected = false
 
@@ -711,9 +687,9 @@ final class InputManager {
         if let ruby = self.getRubyIfPossible(text: text) {
             debug("Evaluated ruby:", ruby)
             // rubyはひらがなである
-            _ = self.composingText.insertAtCursorPosition(ruby, inputStyle: .direct)
+            self.composingText.insertAtCursorPosition(ruby, inputStyle: .direct)
         } else {
-            _ = self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
+            self.composingText.insertAtCursorPosition(text, inputStyle: .direct)
         }
 
         isSelected = true

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -767,9 +767,8 @@ final class InputManager {
         let firstClauseResults: [Candidate]
         (results, firstClauseResults) = self.kanaKanjiConverter.requestCandidates(inputData, options: options)
         if liveConversionEnabled {
-            let operation = self.liveConversionManager.updateWithNewResults(results, firstClauseResults: firstClauseResults, convertTargetCursorPosition: inputData.convertTargetCursorPosition, convertTarget: inputData.convertTarget)
-            debug("Live Conversion View Update: delete \(operation.delete) letters, insert \(operation.input)")
-            self.displayedTextManager.replace(count: operation.delete, with: operation.input)
+            let liveConversionText = self.liveConversionManager.updateWithNewResults(results, firstClauseResults: firstClauseResults, convertTargetCursorPosition: inputData.convertTargetCursorPosition, convertTarget: inputData.convertTarget)
+            self.displayedTextManager.updateLiveConversionText(liveConversionText: liveConversionText)
         }
 
         debug("results to be registered:", results)

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -126,12 +126,6 @@ final class InputManager {
     /// 変換を選択した場合に呼ばれる
     func complete(candidate: Candidate) {
         self.updateLog(candidate: candidate)
-        // カーソルから左の入力部分を削除し、変換後の文字列+残りの文字列を後で入力し直す
-        if !self.isSelected {
-            // 消しすぎることはないのでエラーは無視できる
-            try? self.displayedTextManager.deleteBackward(count: self.displayedTextManager.displayedTextCursorPosition)
-        }
-
         self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
         self.displayedTextManager.updateComposingText(composingText: self.composingText, completedPrefix: candidate.text, isSelected: &self.isSelected)
 
@@ -204,7 +198,7 @@ final class InputManager {
         if simpleInsert {
             // 必要に応じて確定する
             _ = self.enter()
-            self.displayedTextManager.insertText(text, shouldSimplyInsert: true)
+            self.displayedTextManager.insertText(text)
             return
         }
         if self.isSelected {

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -293,8 +293,11 @@ final class InputManager {
 
     /// テキストの進行方向と逆に削除する
     /// `ab|c → a|c`のイメージ
-    func deleteBackward(count: Int, requireSetResult: Bool = true) {
-        if count == 0 {
+    /// - Parameters:
+    ///   - convertTargetCount: `convertTarget`の文字数。`displayedText`の文字数ではない。
+    ///   - requireSetResult: `setResult()`の呼び出しを要求するか。
+    func deleteBackward(convertTargetCount: Int, requireSetResult: Bool = true) {
+        if convertTargetCount == 0 {
             return
         }
         // 選択状態ではオール削除になる
@@ -304,17 +307,17 @@ final class InputManager {
             return
         }
         // 条件
-        if count < 0 {
-            self.deleteForward(count: abs(count), requireSetResult: requireSetResult)
+        if convertTargetCount < 0 {
+            self.deleteForward(count: abs(convertTargetCount), requireSetResult: requireSetResult)
             return
         }
         guard !self.composingText.isEmpty else {
             // 消し過ぎの可能性は考えなくて大丈夫な状況
-            try? self.displayedTextManager.deleteBackward(count: count, isComposing: false)
+            try? self.displayedTextManager.deleteBackward(count: convertTargetCount, isComposing: false)
             return
         }
 
-        let operation = self.composingText.deleteBackwardFromCursorPosition(count: count)
+        let operation = self.composingText.deleteBackwardFromCursorPosition(count: convertTargetCount)
         debug("Input Manager deleteBackword: ", composingText)
 
         // 削除を実行する
@@ -561,7 +564,7 @@ final class InputManager {
             for count in (counts.min...counts.max).reversed() where count <= composingText.convertTargetCursorPosition {
                 if let replace = table[String(leftside.suffix(count))] {
                     // deleteとinputを効率的に行うため、setResultを要求しない (変換を行わない)
-                    self.deleteBackward(count: leftside.suffix(count).count, requireSetResult: false)
+                    self.deleteBackward(convertTargetCount: leftside.suffix(count).count, requireSetResult: false)
                     // ここで変換が行われる。内部的には差分管理システムによって「置換」の場合のキャッシュ変換が呼ばれる。
                     self.input(text: replace, requireSetResult: requireSetResult)
                     found = true
@@ -600,7 +603,7 @@ final class InputManager {
             return
         }
         // deleteとinputを効率的に行うため、setResultを要求しない (変換を行わない)
-        self.deleteBackward(count: 1, requireSetResult: false)
+        self.deleteBackward(convertTargetCount: 1, requireSetResult: false)
         // inputの内部でsetResultが発生する
         self.input(text: changed, requireSetResult: requireSetResult)
     }

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -77,7 +77,8 @@ final class KeyboardActionManager: UserActionManager {
             } else {
                 self.inputManager.input(text: text, requireSetResult: requireSetResult)
             }
-
+        case let .insertMainDisplay(text):
+            self.inputManager.insertMainDisplayText(text)
         case let .delete(count):
             self.showResultView()
             self.inputManager.deleteBackward(convertTargetCount: count, requireSetResult: requireSetResult)

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -157,6 +157,20 @@ final class KeyboardActionManager: UserActionManager {
         case let .moveTab(type):
             VariableStates.shared.setTab(type)
 
+        case let .setUpsideComponent(type):
+            switch type {
+            case nil:
+                if VariableStates.shared.upsideComponent != nil {
+                    VariableStates.shared.upsideComponent = nil
+                    self.delegate.reloadAllView()
+                } else {
+                    VariableStates.shared.upsideComponent = nil
+                }
+            case .some:
+                VariableStates.shared.upsideComponent = type
+                self.delegate.reloadAllView()
+            }
+
         case let .setTabBar(operation):
             switch operation {
             case .on:
@@ -206,16 +220,6 @@ final class KeyboardActionManager: UserActionManager {
                     self.registerActions(falseAction)
                 }
             }
-        case let .setFullScreenKeyboard(operation):
-            switch operation {
-            case .on:
-                VariableStates.shared.boolStates.isScreenExpanded = true
-            case .off:
-                VariableStates.shared.boolStates.isScreenExpanded = false
-            case .toggle:
-                VariableStates.shared.boolStates.isScreenExpanded.toggle()
-            }
-            self.delegate.reloadAllView()
         #if DEBUG
         // MARK: デバッグ用
         case .DEBUG_DATA_INPUT:

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -18,7 +18,6 @@ final class KeyboardActionManager: UserActionManager {
     // 即時変数
     private var timers: [(type: LongpressActionType, timer: Timer)] = []
     private var tempTextData: (left: String, center: String, right: String)!
-    private var tempSavedSelectedText: String!
 
     // キーボードを閉じる際に呼び出す
     // inputManagerはキーボードを閉じる際にある種の操作を行う
@@ -103,17 +102,6 @@ final class KeyboardActionManager: UserActionManager {
 
         case .deselectAndUseAsInputting:
             self.inputManager.edit()
-
-        case .saveSelectedTextIfNeeded:
-            if self.inputManager.isSelected {
-                self.tempSavedSelectedText = self.inputManager.composingText.convertTarget
-            }
-
-        case .restoreSelectedTextIfNeeded:
-            if let tmp = self.tempSavedSelectedText {
-                self.inputManager.input(text: tmp)
-                self.tempSavedSelectedText = nil
-            }
 
         case let .moveCursor(count):
             self.inputManager.moveCursor(count: count, requireSetResult: requireSetResult)

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -81,7 +81,7 @@ final class KeyboardActionManager: UserActionManager {
 
         case let .delete(count):
             self.showResultView()
-            self.inputManager.deleteBackward(count: count, requireSetResult: requireSetResult)
+            self.inputManager.deleteBackward(convertTargetCount: count, requireSetResult: requireSetResult)
 
         case .smoothDelete:
             KeyboardFeedback.smoothDelete()

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -202,6 +202,16 @@ final class KeyboardActionManager: UserActionManager {
                     self.registerActions(falseAction)
                 }
             }
+        case let .setFullScreenKeyboard(operation):
+            switch operation {
+            case .on:
+                VariableStates.shared.boolStates.isScreenExpanded = true
+            case .off:
+                VariableStates.shared.boolStates.isScreenExpanded = false
+            case .toggle:
+                VariableStates.shared.boolStates.isScreenExpanded.toggle()
+            }
+            self.delegate.reloadAllView()
         #if DEBUG
         // MARK: デバッグ用
         case .DEBUG_DATA_INPUT:

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -236,30 +236,32 @@ final class KeyboardViewController: UIInputViewController {
      debug("selectionDidChange")
      }
      */
+    /// 引数の`textInput`は常に`nil`
     override func textWillChange(_ textInput: UITextInput?) {
         super.textWillChange(textInput)
 
-        VariableStates.shared.setUIReturnKeyType(type: self.textDocumentProxy.returnKeyType ?? .default)
         let left = self.textDocumentProxy.documentContextBeforeInput ?? ""
         let center = self.textDocumentProxy.selectedText ?? ""
         let right = self.textDocumentProxy.documentContextAfterInput ?? ""
+        debug("KeyboardViewController.textWillChange", left, center, right)
 
-        debug(left, center, right)
         Self.action.notifySomethingWillChange(left: left, center: center, right: right)
     }
 
+    /// 引数の`textInput`は常に`nil`
     override func textDidChange(_ textInput: UITextInput?) {
         super.textDidChange(textInput)
 
         let left = self.textDocumentProxy.documentContextBeforeInput ?? ""
         let center = self.textDocumentProxy.selectedText ?? ""
         let right = self.textDocumentProxy.documentContextAfterInput ?? ""
+        debug("KeyboardViewController.textDidChange", left, center, right)
 
-        debug(left, center, right)
         Self.action.notifySomethingDidChange(a_left: left, a_center: center, a_right: right)
-
+        Self.action.setTextDocumentProxy(.preference(.main))
         // このタイミングでクリップボードを確認する
         VariableStates.shared.clipboardHistoryManager.checkUpdate()
+        VariableStates.shared.setUIReturnKeyType(type: self.textDocumentProxy.returnKeyType ?? .default)
     }
 
     @objc func openURL(_ url: URL) {}

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -77,7 +77,7 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        debug("viewDidLoad, loadedInstanceCount:", KeyboardViewController.loadedInstanceCount)
+        debug("KeyboardViewController.viewDidLoad, loadedInstanceCount:", KeyboardViewController.loadedInstanceCount)
         KeyboardViewController.loadedInstanceCount += 1
 
         // 初期化の順序としてこの位置に置くこと
@@ -87,17 +87,7 @@ final class KeyboardViewController: UIInputViewController {
         @KeyboardSetting(.keyboardHeightScale) var keyboardHeightScale: Double
         SemiStaticStates.shared.setKeyboardHeightScale(keyboardHeightScale)
 
-        let indexManager = ThemeIndexManager.load()
-        let theme: ThemeData
-        switch traitCollection.userInterfaceStyle {
-        case .unspecified, .light:
-            theme = (try? indexManager.theme(at: indexManager.selectedIndex)) ?? .default
-        case .dark:
-            theme = (try? indexManager.theme(at: indexManager.selectedIndexInDarkMode)) ?? .default
-        @unknown default:
-            theme = (try? indexManager.theme(at: indexManager.selectedIndex)) ?? .default
-        }
-        let host = KeyboardViewController.keyboardViewHost ?? KeyboardHostingController(rootView: Keyboard(theme: theme))
+        let host = KeyboardViewController.keyboardViewHost ?? KeyboardHostingController(rootView: Keyboard(theme: getCurrentTheme()))
         // コントロールセンターを出しにくくする。
         host.setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
 
@@ -112,14 +102,26 @@ final class KeyboardViewController: UIInputViewController {
         host.view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         host.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
 
+        self.view.heightAnchor.constraint(equalTo: host.view.heightAnchor).isActive = true
+
         KeyboardViewController.keyboardViewHost = host
         KeyboardViewController.action.setDelegateViewController(self)
+    }
 
-        debug("viewDidLoad", self.isViewLoaded, UIScreen.main.bounds.size, UIScreen.main.currentMode?.size, self.view.window?.bounds)
+    private func getCurrentTheme() -> ThemeData {
+        let indexManager = ThemeIndexManager.load()
+        switch traitCollection.userInterfaceStyle {
+        case .unspecified, .light:
+            return (try? indexManager.theme(at: indexManager.selectedIndex)) ?? .default
+        case .dark:
+            return (try? indexManager.theme(at: indexManager.selectedIndexInDarkMode)) ?? .default
+        @unknown default:
+            return (try? indexManager.theme(at: indexManager.selectedIndex)) ?? .default
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        debug("viewDidAppear")
+        debug("KeyboardViewController.viewDidAppear")
         // キーボードタイプはviewDidAppearのタイミングで取得できる
         VariableStates.shared.setKeyboardType(self.textDocumentProxy.keyboardType)
         // フルアクセスの状態を反映する
@@ -162,7 +164,7 @@ final class KeyboardViewController: UIInputViewController {
 
     func registerScreenActualSize() {
         if let bounds = KeyboardViewController.keyboardViewHost?.view.safeAreaLayoutGuide.owningView?.bounds {
-            debug("registerScreenActualSize width: ", bounds.width)
+            debug("KeyboardViewController.registerScreenActualSize bounds", bounds)
             SemiStaticStates.shared.setScreenWidth(bounds.width)
         }
     }
@@ -178,11 +180,11 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        debug("KeyboardViewController.viewWillDisappear: キーボードが閉じられます")
         KeyboardViewController.action.closeKeyboard()
         VariableStates.shared.closeKeyboard()
         KeyboardViewController.keyboardViewHost = nil
         KeyboardViewController.loadedInstanceCount -= 1
-        debug("viewWillDisappear: キーボードが閉じられます")
         super.viewWillDisappear(animated)
         self.view.clearAllView()
         self.removeFromParent()
@@ -192,8 +194,7 @@ final class KeyboardViewController: UIInputViewController {
         super.viewWillTransition(to: size, with: coordinator)
         // この関数は「これから」向きが変わる場合に呼ばれるので、デバイスの向きによってwidthとheightが逆転するUIScreen.main.bounds.sizeを用いて向きを確かめることができる。
         // ただしこの時点でのUIScreen.mainの値はOSバージョンで変わる
-        // なお、UIScreen.mainは非推奨である。これからデバイスの向きどうやってとったらええねん。
-        debug("viewWillTransition", size, UIScreen.main.bounds.size)
+        debug("KeyboardViewController.viewWillTransition", size, UIScreen.main.bounds.size)
         if #available(iOS 16, *) {
             SemiStaticStates.shared.setScreenWidth(size.width, orientation: UIScreen.main.bounds.width < UIScreen.main.bounds.height ? .horizontal : .vertical)
         } else {
@@ -203,10 +204,24 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        debug("viewDidLayoutSubviews", Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth), SemiStaticStates.shared.screenWidth)
-        self.view.frame.size.height = Design.keyboardScreenHeight
-        self.updateViewConstraints()
-        debug("viewDidLayoutSubviews", UIScreen.main.bounds, self.view.frame.size, KeyboardViewController.keyboardViewHost?.view.frame.size, self.view.window?.bounds, KeyboardViewController.keyboardViewHost?.view.window?.bounds, KeyboardViewController.keyboardViewHost?.view.window?.window?.bounds)
+        debug("KeyboardViewController.viewDidLayoutSubviews", SemiStaticStates.shared.screenWidth,　Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth))
+        if #available(iOS 16, *) {
+            self.view.frame.size.height = Design.keyboardScreenHeight
+        } else {
+            self.view.frame.size.height = Design.keyboardScreenHeight
+            self.updateViewConstraints()
+        }
+    }
+
+    func reloadAllView() {
+        debug("KeyboardViewController.reloadAllView")
+        // subviewsを一度完全に削除する
+        self.view.subviews.forEach {$0.clearAllView()}
+        self.children.forEach {$0.removeFromParent()}
+        KeyboardViewController.keyboardViewHost = nil
+        self.loadViewIfNeeded()
+        self.viewDidLoad()
+        KeyboardViewController.loadedInstanceCount -= 1
     }
 
     /*
@@ -254,7 +269,6 @@ final class KeyboardViewController: UIInputViewController {
         while let r = responder, !r.responds(to: selector) {
             responder = r.next
         }
-        // debug(responder)
         _ = responder?.perform(selector, with: url)
     }
 

--- a/Keyboard/Display/LiveConversionManager.swift
+++ b/Keyboard/Display/LiveConversionManager.swift
@@ -57,11 +57,12 @@ final class LiveConversionManager {
     }
 
     /// かな漢字変換結果を受け取ってライブ変換状態の更新を行う関数
-    func updateWithNewResults(_ candidates: [Candidate], firstClauseResults: [Candidate], convertTargetCursorPosition: Int, convertTarget: String) -> ComposingText.ViewOperation {
+    ///  - Returns: ライブ変換で表示するテキスト
+    func updateWithNewResults(_ candidates: [Candidate], firstClauseResults: [Candidate], convertTargetCursorPosition: Int, convertTarget: String) -> String {
         // TODO: 最後の1単語のライブ変換を抑制したい
         // TODO: ローマ字入力中に最後の単語が優先される問題
         var candidate: Candidate
-        if convertTargetCursorPosition > 1, let firstCandidate = candidates.first(where: {$0.data.map {$0.ruby}.joined().count == convertTarget.count}) {
+        if convertTargetCursorPosition > 1, let firstCandidate = candidates.first(where: {$0.data.map {$0.ruby}.joined().count == convertTarget.count && !$0.isPredictionCandidate}) {
             candidate = firstCandidate
         } else {
             candidate = .init(text: convertTarget, value: 0, correspondingCount: convertTarget.count, lastMid: MIDData.一般.mid, data: [.init(ruby: convertTarget.toKatakana(), cid: CIDData.一般名詞.cid, mid: MIDData.一般.mid, value: 0)])
@@ -71,11 +72,12 @@ final class LiveConversionManager {
 
         // カーソルなどを調整する
         if convertTargetCursorPosition > 0 {
-            let deleteCount = self.calculateNecessaryBackspaceCount(rubyCursorPosition: convertTargetCursorPosition)
             self.setLastUsedCandidate(candidate, firstClauseCandidates: firstClauseResults)
-            return .init(delete: deleteCount, input: candidate.text)
+            return candidate.text
+        } else {
+            self.setLastUsedCandidate(nil)
+            return ""
         }
-        return .init(delete: 0, input: "")
     }
 
     /// `lastUsedCandidate`を更新する関数
@@ -121,30 +123,6 @@ final class LiveConversionManager {
             newCandidate.parseTemplate()
             debug(candidate, newCandidate)
             candidate = newCandidate
-        }
-    }
-
-    /// `insert`の前に削除すべき長さを返す関数。
-    func calculateNecessaryBackspaceCount(rubyCursorPosition: Int) -> Int {
-        if let lastUsedCandidate {
-            // 直前のCandidateでinsertされた長さ
-            // 通常、この文字数を消せば問題がない
-            let lastCount = lastUsedCandidate.text.count
-            // 直前に部分確定が行われた場合は話が異なる
-            // この場合、「本来の文字数 == ルビカウントの和」と「今のカーソルポジション」の差分をとり、その文字数がinsertされたのだと判定していた
-            // 「愛してる」において「愛し」を部分確定した場合を考える
-            // 本来のルビカウントは5である
-            // 一方、rubyCursorPositionとしては2が与えられる
-            // 故に3文字に対応する部分が確定されているので、
-            // 現在のカーソル位置から、直前のCandidateのルビとしての長さを引いている
-            // カーソル位置は「ルビとしての長さ」なので、「田中」に対するrubyCursorPositionは「タナカ|」の3であることが期待できる。
-            // 一方lastUsedCandidate.data.reduce(0) {$0 + $1.ruby.count}はタナカの3文字なので3である。
-            // 従ってこの例ではdelta=0と言える。
-            debug("Live Conversion Delete Count Calc:", lastUsedCandidate, rubyCursorPosition)
-            let delta = rubyCursorPosition - lastUsedCandidate.data.reduce(0) {$0 + $1.ruby.count}
-            return lastCount + delta
-        } else {
-            return rubyCursorPosition
         }
     }
 

--- a/Keyboard/Display/LiveConversionManager.swift
+++ b/Keyboard/Display/LiveConversionManager.swift
@@ -62,7 +62,7 @@ final class LiveConversionManager {
         // TODO: 最後の1単語のライブ変換を抑制したい
         // TODO: ローマ字入力中に最後の単語が優先される問題
         var candidate: Candidate
-        if convertTargetCursorPosition > 1, let firstCandidate = candidates.first(where: {$0.data.map {$0.ruby}.joined().count == convertTarget.count && !$0.isPredictionCandidate}) {
+        if convertTargetCursorPosition > 1, let firstCandidate = candidates.first(where: {$0.data.map {$0.ruby}.joined().count == convertTarget.count}) {
             candidate = firstCandidate
         } else {
             candidate = .init(text: convertTarget, value: 0, correspondingCount: convertTarget.count, lastMid: MIDData.一般.mid, data: [.init(ruby: convertTarget.toKatakana(), cid: CIDData.一般名詞.cid, mid: MIDData.一般.mid, value: 0)])

--- a/Keyboard/Display/LiveConversionManager.swift
+++ b/Keyboard/Display/LiveConversionManager.swift
@@ -34,7 +34,9 @@ final class LiveConversionManager {
         // フラグを戻す
         self.isFirstClauseCompletion = false
         // 最初を落とす
-        headClauseCandidateHistories.removeFirst()
+        if !headClauseCandidateHistories.isEmpty {
+            headClauseCandidateHistories.removeFirst()
+        }
     }
 
     private func updateHistories(newCandidate: Candidate, firstClauseCandidates: [Candidate]) {

--- a/Shared/KeyboardView/Action.swift
+++ b/Shared/KeyboardView/Action.swift
@@ -43,6 +43,7 @@ indirect enum ActionType: Equatable {
     // タブの変更
     case moveTab(Tab)
     case setTabBar(BoolOperation)
+    case setFullScreenKeyboard(BoolOperation)
 
     // キーボードを閉じる
     case dismissKeyboard

--- a/Shared/KeyboardView/Action.swift
+++ b/Shared/KeyboardView/Action.swift
@@ -21,6 +21,8 @@ indirect enum ActionType: Equatable {
     case smoothDelete           // テキストの一括削除
     case smartDelete(ScanItem)
 
+    case insertMainDisplay(String)   // displayのproxyにテキストをそのまま入力する
+
     /// クリップボードからペーストする
     ///  - note: フルアクセスがない場合動作しない
     case paste

--- a/Shared/KeyboardView/Action.swift
+++ b/Shared/KeyboardView/Action.swift
@@ -26,9 +26,7 @@ indirect enum ActionType: Equatable {
     case paste
 
     case deselectAndUseAsInputting   // 選択を解除して編集中とみなす
-    // 取り込み関係
-    case saveSelectedTextIfNeeded           // 選択部分が存在していたら一時保存する。
-    case restoreSelectedTextIfNeeded        // 選択部分の一時保存したデータを取り出して代入する
+
     // カーソル関係
     case moveCursor(Int)
     case smartMoveCursor(ScanItem)

--- a/Shared/KeyboardView/Action.swift
+++ b/Shared/KeyboardView/Action.swift
@@ -43,8 +43,7 @@ indirect enum ActionType: Equatable {
     // タブの変更
     case moveTab(Tab)
     case setTabBar(BoolOperation)
-    case setFullScreenKeyboard(BoolOperation)
-
+    case setUpsideComponent(UpsideComponent?)
     // キーボードを閉じる
     case dismissKeyboard
     // アプリを開く

--- a/Shared/KeyboardView/ActionUtils.swift
+++ b/Shared/KeyboardView/ActionUtils.swift
@@ -97,7 +97,7 @@ extension ActionType {
             KeyboardFeedback.smoothDelete()
         case .moveTab, .enter, .changeCharacterType, .setCursorBar, .moveCursor, .enableResizingMode, .replaceLastCharacters, .setTabBar, .setBoolState, .setUpsideComponent/*, ._setBoolState*/:
             KeyboardFeedback.tabOrOtherKey()
-        case .deselectAndUseAsInputting, .saveSelectedTextIfNeeded, .restoreSelectedTextIfNeeded, .openApp, .dismissKeyboard, .hideLearningMemory:
+        case .deselectAndUseAsInputting, .openApp, .dismissKeyboard, .hideLearningMemory:
             return
         case let .boolSwitch(compiledExpression, trueAction, falseAction):
             if let condition = VariableStates.shared.boolStates.evaluateExpression(compiledExpression) {

--- a/Shared/KeyboardView/ActionUtils.swift
+++ b/Shared/KeyboardView/ActionUtils.swift
@@ -95,7 +95,7 @@ extension ActionType {
             KeyboardFeedback.delete()
         case .smoothDelete, .smartDelete, .smartMoveCursor:
             KeyboardFeedback.smoothDelete()
-        case .moveTab, .enter, .changeCharacterType, .setCursorBar, .moveCursor, .enableResizingMode, .replaceLastCharacters, .setTabBar, .setBoolState, .setFullScreenKeyboard/*, ._setBoolState*/:
+        case .moveTab, .enter, .changeCharacterType, .setCursorBar, .moveCursor, .enableResizingMode, .replaceLastCharacters, .setTabBar, .setBoolState, .setUpsideComponent/*, ._setBoolState*/:
             KeyboardFeedback.tabOrOtherKey()
         case .deselectAndUseAsInputting, .saveSelectedTextIfNeeded, .restoreSelectedTextIfNeeded, .openApp, .dismissKeyboard, .hideLearningMemory:
             return

--- a/Shared/KeyboardView/ActionUtils.swift
+++ b/Shared/KeyboardView/ActionUtils.swift
@@ -89,7 +89,7 @@ extension CodableLongpressActionData {
 extension ActionType {
     func feedback() {
         switch self {
-        case .input, .paste:
+        case .input, .paste, .insertMainDisplay:
             KeyboardFeedback.click()
         case .delete:
             KeyboardFeedback.delete()

--- a/Shared/KeyboardView/ActionUtils.swift
+++ b/Shared/KeyboardView/ActionUtils.swift
@@ -95,7 +95,7 @@ extension ActionType {
             KeyboardFeedback.delete()
         case .smoothDelete, .smartDelete, .smartMoveCursor:
             KeyboardFeedback.smoothDelete()
-        case .moveTab, .enter, .changeCharacterType, .setCursorBar, .moveCursor, .enableResizingMode, .replaceLastCharacters, .setTabBar, .setBoolState/*, ._setBoolState*/:
+        case .moveTab, .enter, .changeCharacterType, .setCursorBar, .moveCursor, .enableResizingMode, .replaceLastCharacters, .setTabBar, .setBoolState, .setFullScreenKeyboard/*, ._setBoolState*/:
             KeyboardFeedback.tabOrOtherKey()
         case .deselectAndUseAsInputting, .saveSelectedTextIfNeeded, .restoreSelectedTextIfNeeded, .openApp, .dismissKeyboard, .hideLearningMemory:
             return

--- a/Shared/KeyboardView/Design.swift
+++ b/Shared/KeyboardView/Design.swift
@@ -173,14 +173,14 @@ enum Design {
 
     /// This property calculate suitable width for normal keyView.
     static var keyboardScreenHeight: CGFloat {
-        keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth) + 2
+        keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, hasUpsideComponent: VariableStates.shared.upsideComponent != nil) + 2
     }
 
     /// screenWidthに依存して決定する
     /// 12はresultViewのpadding
-    static func keyboardHeight(screenWidth: CGFloat = VariableStates.shared.interfaceSize.width, isScreenExpanded: Bool? = nil) -> CGFloat {
+    static func keyboardHeight(screenWidth: CGFloat = VariableStates.shared.interfaceSize.width, hasUpsideComponent: Bool = false) -> CGFloat {
         let scale: CGFloat
-        if isScreenExpanded ?? VariableStates.shared.boolStates.isScreenExpanded {
+        if hasUpsideComponent {
             switch orientation {
             case .vertical:
                 scale = max(SemiStaticStates.shared.keyboardHeightScale, 2.2)
@@ -204,12 +204,12 @@ enum Design {
         }
     }
 
+    static func upsideComponentHeight() -> CGFloat {
+        Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, hasUpsideComponent: true) - Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, hasUpsideComponent: false)
+    }
     /// keyboardHeightに依存して決定する
     static func resultViewHeight() -> CGFloat {
-        // 拡大モードではResultViewの幅は変更しない
-        let keyboardHeight: CGFloat = VariableStates.shared.boolStates.isScreenExpanded
-            ? Design.keyboardHeight(isScreenExpanded: false)
-            : VariableStates.shared.interfaceSize.height
+        let keyboardHeight: CGFloat = VariableStates.shared.interfaceSize.height
 
         switch layoutMode {
         case .phoneVertical:

--- a/Shared/KeyboardView/Design.swift
+++ b/Shared/KeyboardView/Design.swift
@@ -172,31 +172,45 @@ enum Design {
     }
 
     /// This property calculate suitable width for normal keyView.
-    /// キーボードの高さはスクリーンの幅から決定するため、キーボードスクリーンの高さはこのように書いて良い。
     static var keyboardScreenHeight: CGFloat {
         keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth) + 2
     }
 
     /// screenWidthに依存して決定する
     /// 12はresultViewのpadding
-    static func keyboardHeight(screenWidth: CGFloat = VariableStates.shared.interfaceSize.width) -> CGFloat {
+    static func keyboardHeight(screenWidth: CGFloat = VariableStates.shared.interfaceSize.width, isScreenExpanded: Bool? = nil) -> CGFloat {
+        let scale: CGFloat
+        if isScreenExpanded ?? VariableStates.shared.boolStates.isScreenExpanded {
+            switch orientation {
+            case .vertical:
+                scale = max(SemiStaticStates.shared.keyboardHeightScale, 2.2)
+            case .horizontal:
+                scale = max(SemiStaticStates.shared.keyboardHeightScale, 1.5)
+            }
+        } else {
+            scale = SemiStaticStates.shared.keyboardHeightScale
+        }
         // 安全装置として、widthが本来のscreenWidthを超えないようにする。
         let width = min(screenWidth, SemiStaticStates.shared.screenWidth)
         switch layoutMode {
         case .phoneVertical:
-            return 51 / 74 * width * SemiStaticStates.shared.keyboardHeightScale + 12
+            return 51 / 74 * width * scale + 12
         case .padVertical:
-            return 15 / 31 * width * SemiStaticStates.shared.keyboardHeightScale + 12
+            return 15 / 31 * width * scale + 12
         case .phoneHorizontal:
-            return 17 / 56 * width * SemiStaticStates.shared.keyboardHeightScale + 12
+            return 17 / 56 * width * scale + 12
         case .padHorizontal:
-            return 5 / 18 * width * SemiStaticStates.shared.keyboardHeightScale + 12
+            return 5 / 18 * width * scale + 12
         }
     }
 
     /// keyboardHeightに依存して決定する
-    static func resultViewHeight(keyboardHeight: CGFloat = VariableStates.shared.interfaceSize.height) -> CGFloat {
-        // let keyboardHeight = self.keyboardHeight(screenWidth: screenWidth)
+    static func resultViewHeight() -> CGFloat {
+        // 拡大モードではResultViewの幅は変更しない
+        let keyboardHeight: CGFloat = VariableStates.shared.boolStates.isScreenExpanded
+            ? Design.keyboardHeight(isScreenExpanded: false)
+            : VariableStates.shared.interfaceSize.height
+
         switch layoutMode {
         case .phoneVertical:
             return (keyboardHeight - 12) * 37 / 204

--- a/Shared/KeyboardView/SemiStaticStates.swift
+++ b/Shared/KeyboardView/SemiStaticStates.swift
@@ -22,21 +22,11 @@ final class SemiStaticStates {
     /// - do not  consider using screenHeight
     /// - スクリーンそのもののサイズ。キーボードビューの幅は片手モードなどによって変更が生じうるため、`screenWidth`は限定的な場面でのみ使うことが望まし。
     private(set) var screenWidth: CGFloat = .zero
-    private(set) var screenHeight: CGFloat = .zero
     private(set) var keyboardHeightScale: CGFloat = 1
 
     /// - note: キーボードが開かれたタイミングで一度呼ぶのが望ましい。
     func setKeyboardHeightScale(_ scale: CGFloat) {
         self.keyboardHeightScale = scale
-    }
-
-    func setScreenHeight(_ height: CGFloat? = nil) {
-        switch VariableStates.shared.keyboardOrientation {
-        case .vertical:
-            self.screenHeight = min(UIScreen.main.bounds.height, height ?? .infinity)
-        case .horizontal:
-            self.screenHeight = min(UIScreen.main.bounds.width, height ?? .infinity)
-        }
     }
 
     /// Function to set the width of area of keyboard

--- a/Shared/KeyboardView/SemiStaticStates.swift
+++ b/Shared/KeyboardView/SemiStaticStates.swift
@@ -22,11 +22,21 @@ final class SemiStaticStates {
     /// - do not  consider using screenHeight
     /// - スクリーンそのもののサイズ。キーボードビューの幅は片手モードなどによって変更が生じうるため、`screenWidth`は限定的な場面でのみ使うことが望まし。
     private(set) var screenWidth: CGFloat = .zero
+    private(set) var screenHeight: CGFloat = .zero
     private(set) var keyboardHeightScale: CGFloat = 1
 
     /// - note: キーボードが開かれたタイミングで一度呼ぶのが望ましい。
     func setKeyboardHeightScale(_ scale: CGFloat) {
         self.keyboardHeightScale = scale
+    }
+
+    func setScreenHeight(_ height: CGFloat? = nil) {
+        switch VariableStates.shared.keyboardOrientation {
+        case .vertical:
+            self.screenHeight = min(UIScreen.main.bounds.height, height ?? .infinity)
+        case .horizontal:
+            self.screenHeight = min(UIScreen.main.bounds.width, height ?? .infinity)
+        }
     }
 
     /// Function to set the width of area of keyboard

--- a/Shared/KeyboardView/Tab.swift
+++ b/Shared/KeyboardView/Tab.swift
@@ -9,6 +9,10 @@
 import CustardKit
 import Foundation
 
+enum UpsideComponent {
+    case chatGPT
+}
+
 enum Tab: Equatable {
     case existential(ExistentialTab)
     case user_dependent(UserDependentTab)

--- a/Shared/KeyboardView/UserActionManager.swift
+++ b/Shared/KeyboardView/UserActionManager.swift
@@ -18,9 +18,27 @@ class UserActionManager {
     func reserveLongPressAction(_ action: LongpressActionType) {}
     func registerLongPressActionEnd(_ action: LongpressActionType) {}
     func notifyComplete(_ candidate: any ResultViewItemData) {}
-    func setInKeyboardProxy(_ proxy: (any UITextDocumentProxy)?) {}
+    func notifySomethingWillChange(left: String, center: String, right: String) {}
+    func notifySomethingDidChange(a_left: String, a_center: String, a_right: String) {}
+    func setTextDocumentProxy(_ proxy: AnyTextDocumentProxy) {}
 
     func makeChangeKeyboardButtonView() -> ChangeKeyboardButtonView {
         ChangeKeyboardButtonView(selector: nil, size: Design.fonts.iconFontSize)
+    }
+}
+
+enum AnyTextDocumentProxy {
+    /// メインの`UITextDocumentProxy`の設定に用いる
+    case mainProxy((any UITextDocumentProxy)?)
+    /// `IKTextEditor`系の`UITextDocumentProxy`の設定に用いる
+    case ikTextFieldProxy((any UITextDocumentProxy)?)
+    /// 設定を切り替える場合に用いる
+    case preference(Preference)
+
+    enum Preference: UInt8 {
+        /// `mainProxy`を優先する
+        case main
+        /// `ikTextFieldProxy`を優先する
+        case ikTextField
     }
 }

--- a/Shared/KeyboardView/VariableStates.swift
+++ b/Shared/KeyboardView/VariableStates.swift
@@ -33,10 +33,12 @@ final class VariableStates: ObservableObject {
         }
 
         var isTextMagnifying = false
+        var isScreenExpanded = false
         var hasFullAccess = false
         var isCapsLocked = false
 
         static let isCapsLockedKey = "isCapsLocked"
+        static let isScreenExpandedKey = "is_screen_expanded"
         static let hasFullAccessKey = "has_full_access"
         // ビルトインのステートとカスタムのステートの両方を適切に扱いたい
         fileprivate var custardStates: [String: Bool] = [:]
@@ -69,12 +71,14 @@ final class VariableStates: ObservableObject {
                     return self.hasFullAccess
                 } else if key == Self.isCapsLockedKey {
                     return self.isCapsLocked
+                } else if key == Self.isScreenExpandedKey {
+                    return self.isScreenExpanded
                 }
                 return custardStates[key]
             }
             set {
                 if let newValue {
-                    if key == Self.hasFullAccessKey {
+                    if key == Self.hasFullAccessKey || key == Self.isScreenExpandedKey {
                         // subscript経由ではRead Onlyにする
                         return
                     } else if key == "isTextMagnifying" {

--- a/Shared/KeyboardView/VariableStates.swift
+++ b/Shared/KeyboardView/VariableStates.swift
@@ -33,12 +33,12 @@ final class VariableStates: ObservableObject {
         }
 
         var isTextMagnifying = false
-        var isScreenExpanded = false
+        var hasUpsideComponent = false
         var hasFullAccess = false
         var isCapsLocked = false
 
         static let isCapsLockedKey = "isCapsLocked"
-        static let isScreenExpandedKey = "is_screen_expanded"
+        static let hasUpsideComponentKey = "is_screen_expanded"
         static let hasFullAccessKey = "has_full_access"
         // ビルトインのステートとカスタムのステートの両方を適切に扱いたい
         fileprivate var custardStates: [String: Bool] = [:]
@@ -71,14 +71,14 @@ final class VariableStates: ObservableObject {
                     return self.hasFullAccess
                 } else if key == Self.isCapsLockedKey {
                     return self.isCapsLocked
-                } else if key == Self.isScreenExpandedKey {
-                    return self.isScreenExpanded
+                } else if key == Self.hasUpsideComponentKey {
+                    return self.hasUpsideComponent
                 }
                 return custardStates[key]
             }
             set {
                 if let newValue {
-                    if key == Self.hasFullAccessKey || key == Self.isScreenExpandedKey {
+                    if key == Self.hasFullAccessKey || key == Self.hasUpsideComponentKey {
                         // subscript経由ではRead Onlyにする
                         return
                     } else if key == "isTextMagnifying" {
@@ -109,6 +109,8 @@ final class VariableStates: ObservableObject {
 
     @Published var keyboardType: UIKeyboardType = .default
 
+    @Published var upsideComponent: UpsideComponent?
+
     @Published var refreshing = true
 
     @Published private(set) var resizingState: ResizingState = .fullwidth
@@ -122,7 +124,8 @@ final class VariableStates: ObservableObject {
     func setResizingMode(_ state: ResizingState) {
         switch state {
         case .fullwidth:
-            interfaceSize = .init(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardScreenHeight)
+            // FIXME: おかしい
+            interfaceSize = .init(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth) + 2)
         case .onehanded, .resizing:
             let item = KeyboardInternalSetting.shared.oneHandedModeSetting.item(layout: keyboardLayout, orientation: keyboardOrientation)
             // キーボードスクリーンのサイズを超えないように設定

--- a/Shared/KeyboardView/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
+++ b/Shared/KeyboardView/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
@@ -26,7 +26,7 @@ struct FlickEnterKeyModel: FlickKeyModelProtocol {
         }
     }
 
-    var longPressActions: LongpressActionType = .none
+    var longPressActions: LongpressActionType = .init(start: [.setUpsideComponent(.chatGPT)])
 
     var flickKeys: [FlickDirection: FlickedKeyModel] = [:]
 

--- a/Shared/KeyboardView/View/KeyboardView.swift
+++ b/Shared/KeyboardView/View/KeyboardView.swift
@@ -94,7 +94,14 @@ struct KeyboardView<Candidate: ResultViewItemData>: View {
                         }
                     }
                 )
-            Group {
+            VStack(spacing: 0) {
+                if let upsideComponent = variableStates.upsideComponent {
+                    switch upsideComponent {
+                    case .chatGPT:
+                        ChatGPTInteractionTab()
+                            .frame(height: Design.upsideComponentHeight())
+                    }
+                }
                 if isResultViewExpanded {
                     ExpandedResultView(isResultViewExpanded: $isResultViewExpanded, resultData: resultData)
                 } else {

--- a/Shared/KeyboardView/View/ResizingRect.swift
+++ b/Shared/KeyboardView/View/ResizingRect.swift
@@ -258,7 +258,11 @@ struct ResizingRect: View {
                         )
                 }
                 Button {
-                    VariableStates.shared.setResizingMode(.onehanded)
+                    if self.position == .zero && self.size == self.initialSize {
+                        VariableStates.shared.setResizingMode(.fullwidth)
+                    } else {
+                        VariableStates.shared.setResizingMode(.onehanded)
+                    }
                 }label: {
                     Circle()
                         .fill(Color.blue)
@@ -351,11 +355,12 @@ struct ResizingBindingFrame: ViewModifier {
                     self.position = .zero
                     self.size.width = initialSize.width
                     self.size.height = initialSize.height
+                    VariableStates.shared.setResizingMode(.fullwidth)
                 }
                 KeyboardInternalSetting.shared.update(\.oneHandedModeSetting) {value in
                     value.set(layout: VariableStates.shared.keyboardLayout, orientation: VariableStates.shared.keyboardOrientation, size: initialSize, position: .zero)
                 }
-            }label: {
+            } label: {
                 Circle()
                     .fill(Color.red)
                     .frame(width: r, height: r)

--- a/Shared/KeyboardView/View/ResultView/InKeyboardTextEditor.swift
+++ b/Shared/KeyboardView/View/ResultView/InKeyboardTextEditor.swift
@@ -107,7 +107,9 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     }
 
     func unmarkText() {
-        self.input.unmarkText()
+        if self.input.markedTextRange != nil {
+            self.input.unmarkText()
+        }
     }
 
     var hasText: Bool {
@@ -115,6 +117,10 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     }
 
     func insertText(_ text: String) {
+        if self.input.markedTextRange != nil {
+            self.setMarkedText("", selectedRange: .init())
+            self.input.unmarkText()
+        }
         self.input.insertText(text)
     }
 

--- a/Shared/KeyboardView/View/ResultView/InKeyboardTextEditor.swift
+++ b/Shared/KeyboardView/View/ResultView/InKeyboardTextEditor.swift
@@ -62,6 +62,9 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     private var input: any UITextInput
 
     var documentContextBeforeInput: String? {
+        if self.input.markedTextRange != nil {
+            return nil
+        }
         // カーソル位置は`selectedTextRange`で取得できる。
         if let start = self.input.selectedTextRange?.start,
            let range = self.input.textRange(from: self.input.beginningOfDocument, to: start) {
@@ -71,6 +74,9 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     }
 
     var documentContextAfterInput: String? {
+        if self.input.markedTextRange != nil {
+            return nil
+        }
         // カーソル位置は`selectedTextRange`で取得できる。
         if let end = self.input.selectedTextRange?.end,
            let range = self.input.textRange(from: end, to: self.input.endOfDocument) {
@@ -80,6 +86,9 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     }
 
     var selectedText: String? {
+        if self.input.markedTextRange != nil {
+            return nil
+        }
         if let range = self.input.selectedTextRange {
             return self.input.text(in: range)
         }
@@ -120,10 +129,6 @@ private final class CustomTextDocumentProxy: NSObject, UITextDocumentProxy {
     }
 
     func insertText(_ text: String) {
-        if self.input.markedTextRange != nil {
-            self.setMarkedText("", selectedRange: .init())
-            self.input.unmarkText()
-        }
         self.input.insertText(text)
     }
 

--- a/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
+++ b/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
@@ -1,0 +1,127 @@
+//
+//  ChatGPTInteractionTab.swift
+//  azooKey
+//
+//  Created by ensan on 2023/03/10.
+//  Copyright © 2023 ensan. All rights reserved.
+//
+
+import Foundation
+import OpenAISwift
+import SwiftUI
+
+struct ChatGPTInteractionTab: View {
+    @ObservedObject private var variableStates = VariableStates.shared
+    @Environment(\.userActionManager) private var action
+    @State private var userPrompt = ""
+    @State private var messages: [ChatMessage] = [.init(role: .assistant, content: "知りたいことや、やりたいことを教えてください！")]
+    @FocusState private var textEditorFocused
+    private let openAI = OpenAISwift(authToken: "")
+
+    private var textEditorConfig: InKeyboardTextEditor.Configuration {
+        .init(backgroundColor: .background)
+    }
+    var tabDependentDesign: TabDependentDesign {
+        TabDependentDesign(width: 7, height: 4, layout: .flick, orientation: VariableStates.shared.keyboardOrientation)
+    }
+
+    private func backgroundColor(role: ChatRole) -> Color {
+        switch role {
+        case .system:
+            return .gray
+        case .user:
+            return .green
+        case .assistant:
+            return .background
+        }
+    }
+    @ViewBuilder
+    private func messageView(_ message: ChatMessage) -> some View {
+        Text(message.content)
+            .padding(8)
+            .background(self.backgroundColor(role: message.role))
+            .cornerRadius(12)
+            .foregroundColor(Color.primary)
+            .padding(.horizontal, 10)
+            .contextMenu {
+                Button {
+                    self.textEditorFocused = false
+                } label: {
+                    Label("この文章を入力する", systemImage: "rectangle.and.pencil.and.ellipsis")
+                }
+            }
+    }
+
+    var body: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button {
+                    action.registerAction(.setUpsideComponent(nil))
+                } label: {
+                    Image(systemName: "xmark")
+                }
+            }
+            ScrollView {
+                ForEach(messages.indices, id: \.self) { i in
+                    switch messages[i].role {
+                    case .user:
+                        HStack {
+                            Spacer()
+                            messageView(messages[i])
+                        }
+                    case .system:
+                        HStack {
+                            Spacer()
+                            messageView(messages[i])
+                            Spacer()
+                        }
+                    case .assistant:
+                        HStack {
+                            messageView(messages[i])
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            HStack {
+                InKeyboardTextEditor(text: $userPrompt, configuration: textEditorConfig)
+                    .frame(width: tabDependentDesign.keyViewWidth(widthCount: 6), height: tabDependentDesign.keyViewHeight)
+                    .cornerRadius(12)
+                    .focused($textEditorFocused)
+                Button {
+                    guard !userPrompt.isEmpty else {
+                        return
+                    }
+                    self.messages.append(ChatMessage(role: .user, content: userPrompt))
+                    self.userPrompt = ""
+                    Task {
+                        do {
+                            let messages: [ChatMessage] = [.init(role: .system, content: "You are native Japanese speaker and you should answer in Japanese. Be positive and use emoji!")] + Array(self.messages.dropFirst().suffix(10))
+                            debug("ChatGPTInteractionTab send messages", messages)
+                            let response = try await openAI.sendChat(with: messages, model: .chat(.chatgpt))
+                            let result = response.choices
+                            if let responseMessage = result.first?.message {
+                                self.messages.append(responseMessage)
+                            }
+                        } catch {
+                            #if DEBUG
+                            debug("ChatGPTInteractionTab error", error)
+                            self.messages.append(ChatMessage(role: .system, content: "エラーが発生しました。\(error.localizedDescription)"))
+                            #else
+                            self.messages.append(ChatMessage(role: .system, content: "エラーが発生しました。"))
+                            #endif
+                        }
+                    }
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(Font.system(size: tabDependentDesign.keyViewHeight * 0.5))
+                        .frame(width: tabDependentDesign.keyViewWidth, height: tabDependentDesign.keyViewHeight)
+                }
+            }
+        }
+        .onAppear {
+            self.textEditorFocused = true
+        }
+    }
+}

--- a/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
+++ b/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
@@ -45,7 +45,7 @@ struct ChatGPTInteractionTab: View {
             .padding(.horizontal, 10)
             .contextMenu {
                 Button {
-                    self.textEditorFocused = false
+                    action.registerAction(.insertMainDisplay(message.content))
                 } label: {
                     Label("この文章を入力する", systemImage: "rectangle.and.pencil.and.ellipsis")
                 }
@@ -97,7 +97,7 @@ struct ChatGPTInteractionTab: View {
                     self.userPrompt = ""
                     Task {
                         do {
-                            let messages: [ChatMessage] = [.init(role: .system, content: "You are native Japanese speaker and you should answer in Japanese. Be positive and use emoji!")] + Array(self.messages.dropFirst().suffix(10))
+                            let messages: [ChatMessage] = [.init(role: .system, content: "You are native Japanese speaker and you should answer in Japanese. Be positive and friendly!")] + Array(self.messages.dropFirst().suffix(10))
                             debug("ChatGPTInteractionTab send messages", messages)
                             let response = try await openAI.sendChat(with: messages, model: .chat(.chatgpt))
                             let result = response.choices

--- a/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
+++ b/Shared/KeyboardView/View/SpecialTabs/ChatGPTInteractionTab.swift
@@ -11,11 +11,50 @@ import OpenAISwift
 import SwiftUI
 
 struct ChatGPTInteractionTab: View {
+    struct Message: Codable {
+        var role: ChatRole
+        var content: String
+        var orderType: ChatBasedOrder = .none
+
+        var text: String {
+            let newContent: String
+            switch self.orderType {
+            case .none:
+                newContent = content
+            case .writeMore:
+                newContent = "「\(content)」の続きを書いてください"
+            case .summary:
+                newContent = "「\(content)」を要約してください"
+            case .makeBetter:
+                newContent = "「\(content)」の印象をよくしてください"
+            case .checkErrors:
+                newContent = "「\(content)」を校閲してください"
+            case .englishTranslation:
+                newContent = "「\(content)」を英語翻訳してください"
+            }
+            return newContent
+        }
+
+        func toChatMessage() -> ChatMessage {
+            .init(role: role, content: text)
+        }
+    }
+
+    enum ChatBasedOrder: UInt8, Codable {
+        case none
+        case writeMore
+        case makeBetter
+        case checkErrors
+        case summary
+        case englishTranslation
+    }
+
     @ObservedObject private var variableStates = VariableStates.shared
     @Environment(\.userActionManager) private var action
     @State private var lastIndex = 0
     @State private var userPrompt = ""
-    @State private var messages: [ChatMessage] = [.init(role: .assistant, content: "知りたいことや、やりたいことを教えてください！")]
+    @State private var lastInsertedText: String?
+    @State private var messages: [Message] = [.init(role: .assistant, content: "知りたいことや、やりたいことを教えてください！")]
     @FocusState private var textEditorFocused
     private let openAI = OpenAISwift(authToken: "")
 
@@ -36,9 +75,119 @@ struct ChatGPTInteractionTab: View {
             return .background
         }
     }
+
+    private func chatPrompt(_ type: ChatBasedOrder, userContent: String) {
+        if !userContent.isEmpty {
+            self.appendMessage(.init(role: .user, content: userContent, orderType: type))
+            self.userPrompt = ""
+
+            Task {
+                do {
+                    let systemContent: String
+                    switch type {
+                    case .makeBetter: systemContent = "Rewrite the given text in a way that makes a good impression on native speakers of the language, and then return the rewriten text. If you explain points, use user language. Keep tone of the given text."
+                    case .summary: systemContent = "Shorten the given text with small loss of information in given language. No translation is required."
+                    case .checkErrors: systemContent = "Check grammatical or stylistic errors, inconsistencies, and other non-fluent points, and return text which explains the errors in user language. If the given text is perfect, just praise it in user language."
+                    case .writeMore: systemContent = "Write the content which continues from user's input in given language."
+                    case .englishTranslation: systemContent = "Translate Japanese to English."
+                    case .none: systemContent = "You are native Japanese speaker and you should answer in Japanese. Be positive and friendly!"
+                    }
+                    let messages: [ChatMessage] = [
+                        .init(role: .system, content: systemContent),
+                        .init(role: .user, content: userContent)
+                    ]
+                    debug("ChatGPTInteractionTab send input", userContent, type)
+                    let result = try await openAI.sendChat(with: messages, model: .chat(.chatgpt))
+                    if let response = result.choices.first?.message {
+                        self.appendMessage(.init(role: .assistant, content: response.content))
+                    }
+                } catch {
+                    self.requestError(error)
+                }
+            }
+        }
+    }
+
+    private var promptSuggestions: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                if userPrompt.isEmpty {
+                    Button("ペースト") {
+                        action.registerAction(.paste)
+                    }
+                }
+                if let lastInsertedText {
+                    Button("取り消し") {
+                        action.setTextDocumentProxy(.preference(.main))
+                        action.registerAction(.delete(lastInsertedText.count))
+                        self.lastInsertedText = nil
+                        action.setTextDocumentProxy(.preference(.ikTextField))
+                    }
+                    .onChange(of: variableStates.textChangedCount) { _ in
+                        self.lastInsertedText = nil
+                    }
+                } else if messages.count > 1, let last = messages.last, last.role == .assistant {
+                    Button("回答を入力") {
+                        self.input(last.content)
+                    }
+                }
+                if !userPrompt.isEmpty {
+                    Button("好印象にする") {
+                        chatPrompt(.makeBetter, userContent: userPrompt)
+                    }
+                    Button("英語翻訳") {
+                        chatPrompt(.englishTranslation, userContent: userPrompt)
+                    }
+                    Button("校閲") {
+                        chatPrompt(.checkErrors, userContent: userPrompt)
+                    }
+                    Button("要約") {
+                        chatPrompt(.summary, userContent: userPrompt)
+                    }
+                }
+                Button("閉じる") {
+                    action.registerAction(.setUpsideComponent(nil))
+                }
+            }
+        }
+        .frame(height: tabDependentDesign.keyViewHeight * 0.5)
+        .buttonStyle(.bordered)
+    }
+
+    private struct ResponseWaitingView: View {
+        private let startDate = Date()
+        private let circleCount = 5
+        private let interval = 0.2
+        private let circleSize = 11.0
+
+        var body: some View {
+            TimelineView(.periodic(from: startDate, by: interval)) { context in
+                let selection = Int((context.date.timeIntervalSince(startDate)) / interval) % (circleCount)
+                HStack(spacing: 5) {
+                    ForEach(0..<circleCount, id: \.self) { index in
+                        Circle()
+                            .fill(Color.systemGray5)
+                            .frame(width: circleSize, height: circleSize)
+                            .scaleEffect(index == selection ? 1.3 : 1.0)
+                            .animation(.easeInOut(duration: interval), value: selection)
+                    }
+                }
+            }
+        }
+    }
+
+    private var responseWaitingView: some View {
+        ResponseWaitingView()
+            .padding(8)
+            .background(self.backgroundColor(role: .assistant))
+            .cornerRadius(12)
+            .foregroundColor(Color.primary)
+            .padding(.horizontal, 10)
+    }
+
     @ViewBuilder
-    private func messageView(_ message: ChatMessage) -> some View {
-        Text(message.content)
+    private func messageView(_ message: Message) -> some View {
+        Text(message.text)
             .padding(8)
             .background(self.backgroundColor(role: message.role))
             .cornerRadius(12)
@@ -46,42 +195,50 @@ struct ChatGPTInteractionTab: View {
             .padding(.horizontal, 10)
             .contextMenu {
                 Button {
-                    action.registerAction(.insertMainDisplay(message.content))
+                    self.input(message.text)
                 } label: {
                     Label("この文章を入力する", systemImage: "rectangle.and.pencil.and.ellipsis")
+                }
+                Button {
+                    UIPasteboard.general.string = message.text
+                } label: {
+                    Label("この文章をコピーする", systemImage: "doc.on.doc.fill")
                 }
             }
     }
 
     var body: some View {
         VStack {
-            HStack {
-                Spacer()
-                Button {
-                    action.registerAction(.setUpsideComponent(nil))
-                } label: {
-                    Image(systemName: "xmark")
-                }
-            }
             ScrollView {
                 ScrollViewReader { proxy in
-                    ForEach(messages.indices, id: \.self) { i in
-                        switch messages[i].role {
-                        case .user:
-                            HStack {
-                                Spacer()
-                                messageView(messages[i])
-                            }
-                        case .system:
-                            HStack {
-                                Spacer()
-                                messageView(messages[i])
-                                Spacer()
-                            }
-                        case .assistant:
-                            HStack {
-                                messageView(messages[i])
-                                Spacer()
+                    Group {
+                        ForEach(messages.indices, id: \.self) { i in
+                            VStack {
+                                switch messages[i].role {
+                                case .user:
+                                    HStack {
+                                        Spacer()
+                                        messageView(messages[i])
+                                    }
+                                case .system:
+                                    HStack {
+                                        Spacer()
+                                        messageView(messages[i])
+                                        Spacer()
+                                    }
+                                case .assistant:
+                                    HStack {
+                                        messageView(messages[i])
+                                        Spacer()
+                                    }
+                                }
+                                // 末尾に追加する
+                                if i == messages.endIndex - 1 && messages[i].role == .user {
+                                    HStack {
+                                        responseWaitingView
+                                        Spacer()
+                                    }
+                                }
                             }
                         }
                     }
@@ -92,39 +249,37 @@ struct ChatGPTInteractionTab: View {
                     }
                 }
             }
-            HStack {
-                InKeyboardTextEditor(text: $userPrompt, configuration: textEditorConfig)
-                    .frame(width: tabDependentDesign.keyViewWidth(widthCount: 6), height: tabDependentDesign.keyViewHeight)
-                    .cornerRadius(12)
-                    .focused($textEditorFocused)
-                Button {
-                    guard !userPrompt.isEmpty else {
-                        return
-                    }
-                    self.appendMessage(ChatMessage(role: .user, content: userPrompt))
-                    self.userPrompt = ""
-                    Task {
-                        do {
-                            let messages: [ChatMessage] = [.init(role: .system, content: "You are native Japanese speaker and you should answer in Japanese. Be positive and friendly!")] + Array(self.messages.dropFirst().suffix(10))
-                            debug("ChatGPTInteractionTab send messages", messages)
-                            let response = try await openAI.sendChat(with: messages, model: .chat(.chatgpt))
-                            let result = response.choices
-                            if let responseMessage = result.first?.message {
-                                self.appendMessage(responseMessage)
-                            }
-                        } catch {
-                            #if DEBUG
-                            debug("ChatGPTInteractionTab error", error)
-                            self.appendMessage(ChatMessage(role: .system, content: "エラーが発生しました。\(error.localizedDescription)"))
-                            #else
-                            self.appendMessage(ChatMessage(role: .system, content: "エラーが発生しました。"))
-                            #endif
+            VStack {
+                promptSuggestions
+                HStack {
+                    InKeyboardTextEditor(text: $userPrompt, configuration: textEditorConfig)
+                        .frame(width: tabDependentDesign.keyViewWidth(widthCount: 6), height: tabDependentDesign.keyViewHeight)
+                        .cornerRadius(12)
+                        .focused($textEditorFocused)
+                    Button {
+                        guard !userPrompt.isEmpty else {
+                            return
                         }
+                        self.appendMessage(Message(role: .user, content: userPrompt, orderType: .none))
+                        self.userPrompt = ""
+                        Task {
+                            do {
+                                let messages: [ChatMessage] = [.init(role: .system, content: "You are native Japanese speaker and you should answer in Japanese. Be positive and friendly!")] + Array(self.messages.dropFirst().suffix(10).map {$0.toChatMessage()})
+                                debug("ChatGPTInteractionTab send messages", messages)
+                                let response = try await openAI.sendChat(with: messages, model: .chat(.chatgpt))
+                                let result = response.choices
+                                if let response = result.first?.message {
+                                    self.appendMessage(Message(role: response.role, content: response.content))
+                                }
+                            } catch {
+                                self.requestError(error)
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "paperplane.fill")
+                            .font(Font.system(size: tabDependentDesign.keyViewHeight * 0.5))
+                            .frame(width: tabDependentDesign.keyViewWidth, height: tabDependentDesign.keyViewHeight)
                     }
-                } label: {
-                    Image(systemName: "paperplane.fill")
-                        .font(Font.system(size: tabDependentDesign.keyViewHeight * 0.5))
-                        .frame(width: tabDependentDesign.keyViewWidth, height: tabDependentDesign.keyViewHeight)
                 }
             }
         }
@@ -133,8 +288,22 @@ struct ChatGPTInteractionTab: View {
         }
     }
 
-    private func appendMessage(_ message: ChatMessage) {
+    private func appendMessage(_ message: Message) {
         self.messages.append(message)
         self.lastIndex = self.messages.endIndex - 1
+    }
+
+    private func input(_ text: String) {
+        self.action.registerAction(.insertMainDisplay(text))
+        self.lastInsertedText = text
+    }
+
+    private func requestError(_ error: Error, line: Int = #line) {
+        #if DEBUG
+        debug("ChatGPTInteractionTab error at \(line)", error)
+        self.appendMessage(Message(role: .system, content: "エラーが発生しました。\(error.localizedDescription)"))
+        #else
+        self.appendMessage(Message(role: .system, content: "エラーが発生しました。"))
+        #endif
     }
 }

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -244,6 +244,10 @@
 		1AAC102929B4EE4A0020BDE9 /* FullAccessTipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC102829B4EE4A0020BDE9 /* FullAccessTipsView.swift */; };
 		1AAC102B29B8DA610020BDE9 /* InKeyboardTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC102A29B8DA610020BDE9 /* InKeyboardTextEditor.swift */; };
 		1AAC102C29B8DA610020BDE9 /* InKeyboardTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC102A29B8DA610020BDE9 /* InKeyboardTextEditor.swift */; };
+		1AAC102E29BB13B60020BDE9 /* ChatGPTInteractionTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC102D29BB13B60020BDE9 /* ChatGPTInteractionTab.swift */; };
+		1AAC102F29BB13B60020BDE9 /* ChatGPTInteractionTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAC102D29BB13B60020BDE9 /* ChatGPTInteractionTab.swift */; };
+		1AAC103229BB70FC0020BDE9 /* OpenAISwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1AAC103129BB70FC0020BDE9 /* OpenAISwift */; };
+		1AAC103429BB71300020BDE9 /* OpenAISwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1AAC103329BB71300020BDE9 /* OpenAISwift */; };
 		1AAE3E18281BF9CE00F6F963 /* emoji14.0_dict.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 1AAE3E17281BF9CE00F6F963 /* emoji14.0_dict.tsv */; };
 		1AB50760255EC23C003C0BF2 /* AdditionalDictManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB5075F255EC23C003C0BF2 /* AdditionalDictManageView.swift */; };
 		1AB5076B255ECC3C003C0BF2 /* Trie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB5076A255ECC3C003C0BF2 /* Trie.swift */; };
@@ -635,6 +639,7 @@
 		1AAC102629B25D060020BDE9 /* KeyboardHeightSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHeightSettingView.swift; sourceTree = "<group>"; };
 		1AAC102829B4EE4A0020BDE9 /* FullAccessTipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullAccessTipsView.swift; sourceTree = "<group>"; };
 		1AAC102A29B8DA610020BDE9 /* InKeyboardTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InKeyboardTextEditor.swift; sourceTree = "<group>"; };
+		1AAC102D29BB13B60020BDE9 /* ChatGPTInteractionTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTInteractionTab.swift; sourceTree = "<group>"; };
 		1AAE3E17281BF9CE00F6F963 /* emoji14.0_dict.tsv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = emoji14.0_dict.tsv; sourceTree = "<group>"; };
 		1AB5075F255EC23C003C0BF2 /* AdditionalDictManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalDictManageView.swift; sourceTree = "<group>"; };
 		1AB5076A255ECC3C003C0BF2 /* Trie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trie.swift; sourceTree = "<group>"; };
@@ -750,6 +755,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AAC103229BB70FC0020BDE9 /* OpenAISwift in Frameworks */,
 				1A1ECC9D295DA93D001AD7E0 /* Algorithms in Frameworks */,
 				1A70DFFD291F2D1E00A83849 /* CustardKit in Frameworks */,
 				1A606B06292E53BA00CEDB15 /* CustardExpressionEvaluator in Frameworks */,
@@ -778,6 +784,7 @@
 				1A8E454A28E5711800133D3B /* OrderedCollections in Frameworks */,
 				1A9E908F2822CEC100E73846 /* DequeModule in Frameworks */,
 				1A1ECC9F295DA962001AD7E0 /* Algorithms in Frameworks */,
+				1AAC103429BB71300020BDE9 /* OpenAISwift in Frameworks */,
 				1A606B08292E53C500CEDB15 /* CustardExpressionEvaluator in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1351,6 +1358,7 @@
 			isa = PBXGroup;
 			children = (
 				1ACA28E929AB3C2500B794C8 /* ClipboardHistoryTab.swift */,
+				1AAC102D29BB13B60020BDE9 /* ChatGPTInteractionTab.swift */,
 			);
 			path = SpecialTabs;
 			sourceTree = "<group>";
@@ -1578,6 +1586,7 @@
 				1A70DFFC291F2D1E00A83849 /* CustardKit */,
 				1A606B05292E53BA00CEDB15 /* CustardExpressionEvaluator */,
 				1A1ECC9C295DA93D001AD7E0 /* Algorithms */,
+				1AAC103129BB70FC0020BDE9 /* OpenAISwift */,
 			);
 			productName = MainApp;
 			productReference = 1A3DC1C22500D44A002CAA93 /* azooKey.app */;
@@ -1641,6 +1650,7 @@
 				1A70DFFE291F2D3B00A83849 /* CustardKit */,
 				1A606B07292E53C500CEDB15 /* CustardExpressionEvaluator */,
 				1A1ECC9E295DA962001AD7E0 /* Algorithms */,
+				1AAC103329BB71300020BDE9 /* OpenAISwift */,
 			);
 			productName = Keyboard;
 			productReference = 1A3DC1F92500D488002CAA93 /* Keyboard.appex */;
@@ -1687,6 +1697,7 @@
 				1A70DFFB291F2D1E00A83849 /* XCRemoteSwiftPackageReference "CustardKit" */,
 				1A606B00292E506200CEDB15 /* XCRemoteSwiftPackageReference "BoolExpressionEvaluator" */,
 				1A1ECC9B295DA93D001AD7E0 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
+				1AAC103029BB70FC0020BDE9 /* XCRemoteSwiftPackageReference "OpenAISwift" */,
 			);
 			productRefGroup = 1A3DC1C32500D44A002CAA93 /* Products */;
 			projectDirPath = "";
@@ -1874,6 +1885,7 @@
 				1A9B0A6E2565797E004203BB /* ContactView.swift in Sources */,
 				1AF6797425CEDB9B00F3987B /* QwertyVariationsView.swift in Sources */,
 				1AF6799625CEDBB500F3987B /* FlickEnterKeyModel.swift in Sources */,
+				1AAC102E29BB13B60020BDE9 /* ChatGPTInteractionTab.swift in Sources */,
 				1AF6798725CEDBAE00F3987B /* FlickedKeyModel.swift in Sources */,
 				1A5B1CE026D1E495007D4E1C /* MainApp.swift in Sources */,
 				1A8E454328E1379C00133D3B /* MarkedTextSetting.swift in Sources */,
@@ -2160,6 +2172,7 @@
 				1A3ACF2325FB78D1007E9938 /* OneHandedModeSetting.swift in Sources */,
 				1A3DC2262500D63F002CAA93 /* SuggestView.swift in Sources */,
 				1A3DC20A2500D51F002CAA93 /* KeyboardView.swift in Sources */,
+				1AAC102F29BB13B60020BDE9 /* ChatGPTInteractionTab.swift in Sources */,
 				1A2E5822294F4357004F959B /* TypoCorrection.swift in Sources */,
 				1A58AB0D25037E9E00EB1864 /* ExpandedResultView.swift in Sources */,
 				1A3DC2152500D59F002CAA93 /* FlickKeyView.swift in Sources */,
@@ -2695,6 +2708,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		1AAC103029BB70FC0020BDE9 /* XCRemoteSwiftPackageReference "OpenAISwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/adamrushy/OpenAISwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2737,6 +2758,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1A9E908A2822CEB400E73846 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
+		};
+		1AAC103129BB70FC0020BDE9 /* OpenAISwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1AAC103029BB70FC0020BDE9 /* XCRemoteSwiftPackageReference "OpenAISwift" */;
+			productName = OpenAISwift;
+		};
+		1AAC103329BB71300020BDE9 /* OpenAISwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1AAC103029BB70FC0020BDE9 /* XCRemoteSwiftPackageReference "OpenAISwift" */;
+			productName = OpenAISwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/azooKeyTests/KeyboardTests/ComposingTextTests.swift
+++ b/azooKeyTests/KeyboardTests/ComposingTextTests.swift
@@ -12,14 +12,14 @@ final class ComposingTextTests: XCTestCase {
 
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: InputStyle) {
         for char in sequence {
-            _ = composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
+            composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
         }
     }
 
     func testIsEmpty() throws {
         var c = ComposingText()
         XCTAssertTrue(c.isEmpty)
-        _ = c.insertAtCursorPosition("あ", inputStyle: .direct)
+        c.insertAtCursorPosition("あ", inputStyle: .direct)
         XCTAssertFalse(c.isEmpty)
         c.clear()
         XCTAssertTrue(c.isEmpty)
@@ -29,39 +29,34 @@ final class ComposingTextTests: XCTestCase {
         // ダイレクト
         do {
             var c = ComposingText()
-            var v = c.insertAtCursorPosition("あ", inputStyle: .direct)
+            c.insertAtCursorPosition("あ", inputStyle: .direct)
             XCTAssertEqual(c.input, [ComposingText.InputElement(character: "あ", inputStyle: .direct)])
             XCTAssertEqual(c.convertTarget, "あ")
             XCTAssertEqual(c.convertTargetCursorPosition, 1)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "あ"))
 
-            v = c.insertAtCursorPosition("ん", inputStyle: .direct)
+            c.insertAtCursorPosition("ん", inputStyle: .direct)
             XCTAssertEqual(c, ComposingText(convertTargetCursorPosition: 2, input: [.init(character: "あ", inputStyle: .direct), .init(character: "ん", inputStyle: .direct)], convertTarget: "あん"))
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "ん"))
         }
         // ローマ字
         do {
             let inputStyle = InputStyle.roman2kana
             var c = ComposingText()
-            var v = c.insertAtCursorPosition("a", inputStyle: inputStyle)
+            c.insertAtCursorPosition("a", inputStyle: inputStyle)
             XCTAssertEqual(c.input, [ComposingText.InputElement(character: "a", inputStyle: inputStyle)])
             XCTAssertEqual(c.convertTarget, "あ")
             XCTAssertEqual(c.convertTargetCursorPosition, 1)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "あ"))
 
-            v = c.insertAtCursorPosition("k", inputStyle: inputStyle)
+            c.insertAtCursorPosition("k", inputStyle: inputStyle)
             XCTAssertEqual(c, ComposingText(convertTargetCursorPosition: 2, input: [.init(character: "a", inputStyle: inputStyle), .init(character: "k", inputStyle: inputStyle)], convertTarget: "あk"))
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "k"))
 
-            v = c.insertAtCursorPosition("i", inputStyle: inputStyle)
+            c.insertAtCursorPosition("i", inputStyle: inputStyle)
             XCTAssertEqual(c, ComposingText(convertTargetCursorPosition: 2, input: [.init(character: "a", inputStyle: inputStyle), .init(character: "k", inputStyle: inputStyle), .init(character: "i", inputStyle: inputStyle)], convertTarget: "あき"))
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 1, input: "き"))
         }
         // ローマ字で一気に入力
         do {
             let inputStyle = InputStyle.roman2kana
             var c = ComposingText()
-            let v = c.insertAtCursorPosition("akafa", inputStyle: inputStyle)
+            c.insertAtCursorPosition("akafa", inputStyle: inputStyle)
             XCTAssertEqual(c.input, [
                 ComposingText.InputElement(character: "a", inputStyle: inputStyle),
                 ComposingText.InputElement(character: "k", inputStyle: inputStyle),
@@ -71,7 +66,6 @@ final class ComposingTextTests: XCTestCase {
             ])
             XCTAssertEqual(c.convertTarget, "あかふぁ")
             XCTAssertEqual(c.convertTargetCursorPosition, 4)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "あかふぁ"))
 
         }
         // ローマ字の特殊ケース(促音)
@@ -105,19 +99,16 @@ final class ComposingTextTests: XCTestCase {
         // ミックス
         do {
             var c = ComposingText()
-            var v = c.insertAtCursorPosition("a", inputStyle: .direct)
+            c.insertAtCursorPosition("a", inputStyle: .direct)
             XCTAssertEqual(c.input, [ComposingText.InputElement(character: "a", inputStyle: .direct)])
             XCTAssertEqual(c.convertTarget, "a")
             XCTAssertEqual(c.convertTargetCursorPosition, 1)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "a"))
 
-            v = c.insertAtCursorPosition("k", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("k", inputStyle: .roman2kana)
             XCTAssertEqual(c, ComposingText(convertTargetCursorPosition: 2, input: [.init(character: "a", inputStyle: .direct), .init(character: "k", inputStyle: .roman2kana)], convertTarget: "ak"))
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 0, input: "k"))
 
-            v = c.insertAtCursorPosition("i", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("i", inputStyle: .roman2kana)
             XCTAssertEqual(c, ComposingText(convertTargetCursorPosition: 2, input: [.init(character: "a", inputStyle: .direct), .init(character: "k", inputStyle: .roman2kana), .init(character: "i", inputStyle: .roman2kana)], convertTarget: "aき"))
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: 1, input: "き"))
         }
     }
 
@@ -125,10 +116,10 @@ final class ComposingTextTests: XCTestCase {
         // ダイレクト
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("あいうえお", inputStyle: .direct) // あいうえお|
+            c.insertAtCursorPosition("あいうえお", inputStyle: .direct) // あいうえお|
             _ = c.moveCursorFromCursorPosition(count: -3)  // あい|うえお
             // 「う」を消す
-            let v = c.deleteForwardFromCursorPosition(count: 1)   // あい|えお
+            c.deleteForwardFromCursorPosition(count: 1)   // あい|えお
             XCTAssertEqual(c.input, [
                 ComposingText.InputElement(character: "あ", inputStyle: .direct),
                 ComposingText.InputElement(character: "い", inputStyle: .direct),
@@ -137,16 +128,15 @@ final class ComposingTextTests: XCTestCase {
             ])
             XCTAssertEqual(c.convertTarget, "あいえお")
             XCTAssertEqual(c.convertTargetCursorPosition, 2)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: -1, input: ""))
         }
 
         // ローマ字（危険なケース）
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("akafa", inputStyle: .roman2kana) // あかふぁ|
+            c.insertAtCursorPosition("akafa", inputStyle: .roman2kana) // あかふぁ|
             _ = c.moveCursorFromCursorPosition(count: -1)  // あかふ|ぁ
             // 「ぁ」を消す
-            let v = c.deleteForwardFromCursorPosition(count: 1)   // あかふ
+            c.deleteForwardFromCursorPosition(count: 1)   // あかふ
             XCTAssertEqual(c.input, [
                 ComposingText.InputElement(character: "a", inputStyle: .roman2kana),
                 ComposingText.InputElement(character: "k", inputStyle: .roman2kana),
@@ -155,7 +145,6 @@ final class ComposingTextTests: XCTestCase {
             ])
             XCTAssertEqual(c.convertTarget, "あかふ")
             XCTAssertEqual(c.convertTargetCursorPosition, 3)
-            XCTAssertEqual(v, ComposingText.ViewOperation(delete: -1, input: ""))
         }
 
     }
@@ -163,7 +152,7 @@ final class ComposingTextTests: XCTestCase {
     func testIsRightSideValid() throws {
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("akafatta", inputStyle: .roman2kana) // あかふぁった|
+            c.insertAtCursorPosition("akafatta", inputStyle: .roman2kana) // あかふぁった|
             XCTAssertTrue(ComposingText.isRightSideValid(lastElement: ComposingText.InputElement(character: "a", inputStyle: .roman2kana), convertTargetElements: [ComposingText.ConvertTargetElement(string: "あ", inputStyle: .roman2kana)], of: c.input, to: 1))
             XCTAssertFalse(ComposingText.isRightSideValid(lastElement: ComposingText.InputElement(character: "k", inputStyle: .roman2kana), convertTargetElements: [ComposingText.ConvertTargetElement(string: "あk", inputStyle: .roman2kana)], of: c.input, to: 2))
             XCTAssertTrue(ComposingText.isRightSideValid(lastElement: ComposingText.InputElement(character: "a", inputStyle: .roman2kana), convertTargetElements: [ComposingText.ConvertTargetElement(string: "あか", inputStyle: .roman2kana)], of: c.input, to: 3))
@@ -180,7 +169,7 @@ final class ComposingTextTests: XCTestCase {
     func testGetConvertTargetIfRightSideIsValid() throws {
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("akafatta", inputStyle: .roman2kana) // あかふぁった|
+            c.insertAtCursorPosition("akafatta", inputStyle: .roman2kana) // あかふぁった|
             XCTAssertEqual(
                 ComposingText.getConvertTargetIfRightSideIsValid(
                     lastElement: ComposingText.InputElement(character: "t", inputStyle: .roman2kana),
@@ -193,7 +182,7 @@ final class ComposingTextTests: XCTestCase {
         }
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("kintarou", inputStyle: .roman2kana) // きんたろう|
+            c.insertAtCursorPosition("kintarou", inputStyle: .roman2kana) // きんたろう|
             XCTAssertEqual(
                 ComposingText.getConvertTargetIfRightSideIsValid(
                     lastElement: ComposingText.InputElement(character: "n", inputStyle: .roman2kana),
@@ -209,20 +198,20 @@ final class ComposingTextTests: XCTestCase {
     func testDifferenceSuffix() throws {
         do {
             var c1 = ComposingText()
-            _ = c1.insertAtCursorPosition("hasir", inputStyle: .roman2kana)
+            c1.insertAtCursorPosition("hasir", inputStyle: .roman2kana)
 
             var c2 = ComposingText()
-            _ = c2.insertAtCursorPosition("hasiru", inputStyle: .roman2kana)
+            c2.insertAtCursorPosition("hasiru", inputStyle: .roman2kana)
 
             XCTAssertEqual(c2.differenceSuffix(to: c1).deleted, 0)
             XCTAssertEqual(c2.differenceSuffix(to: c1).addedCount, 1)
         }
         do {
             var c1 = ComposingText()
-            _ = c1.insertAtCursorPosition("tukatt", inputStyle: .roman2kana)
+            c1.insertAtCursorPosition("tukatt", inputStyle: .roman2kana)
 
             var c2 = ComposingText()
-            _ = c2.insertAtCursorPosition("tukatte", inputStyle: .roman2kana)
+            c2.insertAtCursorPosition("tukatte", inputStyle: .roman2kana)
 
             XCTAssertEqual(c2.differenceSuffix(to: c1).deleted, 0)
             XCTAssertEqual(c2.differenceSuffix(to: c1).addedCount, 1)

--- a/azooKeyTests/KeyboardTests/ConverterTests/ConverterTests.swift
+++ b/azooKeyTests/KeyboardTests/ConverterTests/ConverterTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class ConverterTests: XCTestCase {
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: InputStyle) {
         for char in sequence {
-            _ = composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
+            composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
         }
     }
 
@@ -21,14 +21,14 @@ final class ConverterTests: XCTestCase {
         do {
             let converter = KanaKanjiConverter()
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("あずーきーはしんじだいのきーぼーどあぷりです", inputStyle: .direct)
+            c.insertAtCursorPosition("あずーきーはしんじだいのきーぼーどあぷりです", inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             XCTAssertEqual(results.mainResults.first?.text, "azooKeyは新時代のキーボードアプリです")
         }
         do {
             let converter = KanaKanjiConverter()
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた", inputStyle: .direct)
+            c.insertAtCursorPosition("ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた", inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             XCTAssertEqual(results.mainResults.first?.text, "幼少期からテニス水泳野球少林寺拳法など様々なスポーツを経験しながら育ち小学校時代はロサンゼルス近郊に滞在しておりゴルフやテニスを習っていた")
 
@@ -44,7 +44,7 @@ final class ConverterTests: XCTestCase {
         var c = ComposingText()
         let text = "ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた"
         for char in text {
-            _ = c.insertAtCursorPosition(String(char), inputStyle: .direct)
+            c.insertAtCursorPosition(String(char), inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             if c.input.count == text.count {
                 XCTAssertEqual(results.mainResults.first?.text, "幼少期からテニス水泳野球少林寺拳法など様々なスポーツを経験しながら育ち小学校時代はロサンゼルス近郊に滞在しておりゴルフやテニスを習っていた")
@@ -66,7 +66,7 @@ final class ConverterTests: XCTestCase {
             "幼少期からテニス水泳野球少林寺拳法など様々なスポーツを経験しながら育ち小学校時代はロサンゼルス近郊に滞在しておりゴルフやテニスをならっていた"
         ]
         for char in text {
-            _ = c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
+            c.insertAtCursorPosition(String(char), inputStyle: .roman2kana)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             if c.input.count == text.count {
                 XCTAssertTrue(possibles.contains(results.mainResults.first!.text))
@@ -89,7 +89,7 @@ final class ConverterTests: XCTestCase {
             let count = Int.random(in: 1 ... 5)
             let rightIndex = text.index(leftIndex, offsetBy: count, limitedBy: text.endIndex) ?? text.endIndex
             let prefix = String(text[leftIndex ..< rightIndex])
-            _ = c.insertAtCursorPosition(prefix, inputStyle: .direct)
+            c.insertAtCursorPosition(prefix, inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             leftIndex = rightIndex
             if rightIndex == text.endIndex {
@@ -108,14 +108,14 @@ final class ConverterTests: XCTestCase {
         let text = Array("ようしょうきからてにすすいえいやきゅうしょうりんじけんぽうなどさまざまなすぽーつをけいけんしながらそだちしょうがっこうじだいはろさんぜるすきんこうにたいざいしておりごるふやてにすをならっていた")
         let deleteIndices = [1, 4, 8, 10, 15, 18, 20, 21, 23, 25, 26, 28, 29, 33, 34, 37, 39, 40, 42, 44, 45, 49, 51, 54, 58, 60, 62, 64, 67, 69, 70, 75, 80]
         for (i, char) in text.enumerated() {
-            _ = c.insertAtCursorPosition(String(char), inputStyle: .direct)
+            c.insertAtCursorPosition(String(char), inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             if deleteIndices.contains(i) {
                 let count = i % 3 + 1
-                _ = c.deleteBackwardFromCursorPosition(count: count)
+                c.deleteBackwardFromCursorPosition(count: count)
                 _ = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
 
-                _ = c.insertAtCursorPosition(String(text[i-count+1 ... i]), inputStyle: .direct)
+                c.insertAtCursorPosition(String(text[i-count+1 ... i]), inputStyle: .direct)
                 _ = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
             }
             if c.input.count == text.count {
@@ -200,7 +200,7 @@ final class ConverterTests: XCTestCase {
         for (input, expect) in cases {
             let converter = KanaKanjiConverter()
             var c = ComposingText()
-            _ = c.insertAtCursorPosition(input, inputStyle: .direct)
+            c.insertAtCursorPosition(input, inputStyle: .direct)
             let results = converter.requestCandidates(c, options: ConvertRequestOptions(N_best: 5, requireJapanesePrediction: true))
 
             if results.mainResults.first?.text == expect {

--- a/azooKeyTests/KeyboardTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/azooKeyTests/KeyboardTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -12,7 +12,7 @@ final class DicdataStoreTests: XCTestCase {
 
     func sequentialInput(_ composingText: inout ComposingText, sequence: String, inputStyle: InputStyle) {
         for char in sequence {
-            _ = composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
+            composingText.insertAtCursorPosition(String(char), inputStyle: inputStyle)
         }
     }
 
@@ -41,7 +41,7 @@ final class DicdataStoreTests: XCTestCase {
         let dicdataStore = DicdataStore()
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("ヘンカン", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("ヘンカン", inputStyle: .roman2kana)
             let result = dicdataStore.getLOUDSDataInRange(inputData: c, from: 0, toIndexRange: 2..<4)
             XCTAssertFalse(result.contains(where: {$0.data.word == "変"}))
             XCTAssertTrue(result.contains(where: {$0.data.word == "変化"}))
@@ -49,7 +49,7 @@ final class DicdataStoreTests: XCTestCase {
         }
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("ヘンカン", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("ヘンカン", inputStyle: .roman2kana)
             let result = dicdataStore.getLOUDSDataInRange(inputData: c, from: 0, toIndexRange: 0..<4)
             XCTAssertTrue(result.contains(where: {$0.data.word == "変"}))
             XCTAssertTrue(result.contains(where: {$0.data.word == "変化"}))
@@ -57,13 +57,13 @@ final class DicdataStoreTests: XCTestCase {
         }
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("ツカッ", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("ツカッ", inputStyle: .roman2kana)
             let result = dicdataStore.getLOUDSDataInRange(inputData: c, from: 0, toIndexRange: 2..<3)
             XCTAssertTrue(result.contains(where: {$0.data.word == "使っ"}))
         }
         do {
             var c = ComposingText()
-            _ = c.insertAtCursorPosition("ツカッt", inputStyle: .roman2kana)
+            c.insertAtCursorPosition("ツカッt", inputStyle: .roman2kana)
             let result = dicdataStore.getLOUDSDataInRange(inputData: c, from: 0, toIndexRange: 2..<4)
             XCTAssertTrue(result.contains(where: {$0.data.word == "使っ"}))
         }


### PR DESCRIPTION
「改行キー」を長押しするとChatGPTモードに入り、ChatGPTが起動する。チャットのほか、翻訳、要約、テキスト生成などを依頼することができる。結果をそのままテキストフィールドに入力することも可能。

