### PR TITLE
[Fix] ResizingRectにおいて「一見fullwidthに見える」にもかかわらず片手モードが有効な場合がある問題を修正

### DIFF
--- a/Shared/KeyboardView/View/ResizingRect.swift
+++ b/Shared/KeyboardView/View/ResizingRect.swift
@@ -258,7 +258,11 @@ struct ResizingRect: View {
                         )
                 }
                 Button {
-                    VariableStates.shared.setResizingMode(.onehanded)
+                    if self.position == .zero && self.size == self.initialSize {
+                        VariableStates.shared.setResizingMode(.fullwidth)
+                    } else {
+                        VariableStates.shared.setResizingMode(.onehanded)
+                    }
                 }label: {
                     Circle()
                         .fill(Color.blue)
@@ -351,11 +355,12 @@ struct ResizingBindingFrame: ViewModifier {
                     self.position = .zero
                     self.size.width = initialSize.width
                     self.size.height = initialSize.height
+                    VariableStates.shared.setResizingMode(.fullwidth)
                 }
                 KeyboardInternalSetting.shared.update(\.oneHandedModeSetting) {value in
                     value.set(layout: VariableStates.shared.keyboardLayout, orientation: VariableStates.shared.keyboardOrientation, size: initialSize, position: .zero)
                 }
-            }label: {
+            } label: {
                 Circle()
                     .fill(Color.red)
                     .frame(width: r, height: r)


### PR DESCRIPTION
実用上あまり問題にならないが、デバッグ時の混乱をきたすため対処した。