### PR TITLE
[Refactoring] bare `P` -> `any P`の適用

### DIFF
--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -36,7 +36,7 @@ final class DisplayedTextManager {
 
     /// marked textの有効化状態
     private(set) var isMarkedTextEnabled: Bool
-    private var proxy: UITextDocumentProxy! {
+    private var proxy: (any UITextDocumentProxy)! {
         switch preferredTextProxy {
         case .main: return displayedTextProxy
         case .ikTextField: return ikTextFieldProxy ?? displayedTextProxy
@@ -45,9 +45,9 @@ final class DisplayedTextManager {
 
     private var preferredTextProxy: AnyTextDocumentProxy.Preference = .main
     /// キーボード外のテキストを扱う`UITextDocumentProxy`
-    private var displayedTextProxy: UITextDocumentProxy!
+    private var displayedTextProxy: (any UITextDocumentProxy)!
     /// キーボード内テキストフィールドの`UITextDocumentProxy`
-    private var ikTextFieldProxy: UITextDocumentProxy?
+    private var ikTextFieldProxy: (any UITextDocumentProxy)?
 
     func setTextDocumentProxy(_ proxy: AnyTextDocumentProxy) {
         switch proxy {

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -195,7 +195,7 @@ final class KeyboardViewController: UIInputViewController {
         self.removeFromParent()
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         // この関数は「これから」向きが変わる場合に呼ばれるので、デバイスの向きによってwidthとheightが逆転するUIScreen.main.bounds.sizeを用いて向きを確かめることができる。
         // ただしこの時点でのUIScreen.mainの値はOSバージョンで変わる
@@ -241,7 +241,7 @@ final class KeyboardViewController: UIInputViewController {
      }
      */
     /// 引数の`textInput`は常に`nil`
-    override func textWillChange(_ textInput: UITextInput?) {
+    override func textWillChange(_ textInput: (any UITextInput)?) {
         super.textWillChange(textInput)
 
         let left = self.textDocumentProxy.documentContextBeforeInput ?? ""
@@ -253,7 +253,7 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     /// 引数の`textInput`は常に`nil`
-    override func textDidChange(_ textInput: UITextInput?) {
+    override func textDidChange(_ textInput: (any UITextInput)?) {
         super.textDidChange(textInput)
 
         let left = self.textDocumentProxy.documentContextBeforeInput ?? ""

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -42,7 +42,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
     @Binding private var manager: CustardManager
     @State private var showPreview = false
     @State private var copiedKey: UserMadeTenKeyCustard.KeyData?
-    private var models: [KeyPosition: (model: FlickKeyModelProtocol, width: Int, height: Int)] {
+    private var models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] {
         (0..<layout.rowCount).reduce(into: [:]) {dict, x in
             (0..<layout.columnCount).forEach {y in
                 if let value = editingItem.keys[.gridFit(x: x, y: y)] {

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -38,7 +38,7 @@ extension QwertyCustomKey: QwertyKey {}
 extension QwertyVariationKey: QwertyKey {}
 
 private extension QwertyCustomKeysValue {
-    subscript(_ state: Selection) -> QwertyKey {
+    subscript(_ state: Selection) -> any QwertyKey {
         get {
             let sIndex = state.selectIndex
             let lpsIndex = state.longpressSelectIndex

--- a/Shared/Converter/TemplateData.swift
+++ b/Shared/Converter/TemplateData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct TemplateData: Codable {
     var name: String
-    var literal: TemplateLiteralProtocol
+    var literal: any TemplateLiteralProtocol
     var type: TemplateLiteralType
 
     private enum CodingKeys: String, CodingKey {

--- a/Shared/KeyboardView/View/Components/InKeyboardTextInput/InKeyboardSearchBar.swift
+++ b/Shared/KeyboardView/View/Components/InKeyboardTextInput/InKeyboardSearchBar.swift
@@ -148,7 +148,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
             parent.proxyWrapper.proxy = nil
         }
 
-        func notifyWillChange(_ textInput: UITextInput) {
+        func notifyWillChange(_ textInput: any UITextInput) {
             let proxy = IKTextDocumentProxy(input: textInput)
             self.parent.action.notifySomethingWillChange(
                 left: proxy.documentContextBeforeInput ?? "",
@@ -157,7 +157,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
             )
         }
 
-        func notifyDidChange(_ textInput: UITextInput) {
+        func notifyDidChange(_ textInput: any UITextInput) {
             let proxy = IKTextDocumentProxy(input: textInput)
             self.parent.action.notifySomethingDidChange(
                 a_left: proxy.documentContextBeforeInput ?? "",
@@ -170,7 +170,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
         }
 
         // MARK: こちらで`textWillChange`などをハンドルすることで、`KeyboardViewController`では扱われなくなる
-        func selectionWillChange(_ textInput: UITextInput?) {
+        func selectionWillChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.selectionWillChange")
             guard let textInput else {
                 return
@@ -178,7 +178,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
             self.notifyWillChange(textInput)
         }
 
-        func selectionDidChange(_ textInput: UITextInput?) {
+        func selectionDidChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.selectionDidChange")
             guard let textInput else {
                 return
@@ -186,7 +186,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
             self.notifyDidChange(textInput)
         }
 
-        func textWillChange(_ textInput: UITextInput?) {
+        func textWillChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.textWillChange")
             guard let textInput else {
                 return
@@ -194,7 +194,7 @@ private struct SearchBarWrapper: UIViewRepresentable {
             self.notifyWillChange(textInput)
         }
 
-        func textDidChange(_ textInput: UITextInput?) {
+        func textDidChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.textDidChange")
             guard let textInput else {
                 return

--- a/Shared/KeyboardView/View/Components/InKeyboardTextInput/InKeyboardTextEditor.swift
+++ b/Shared/KeyboardView/View/Components/InKeyboardTextInput/InKeyboardTextEditor.swift
@@ -101,7 +101,7 @@ private struct TextViewWrapper: UIViewRepresentable {
             parent.proxyWrapper.proxy = nil
         }
 
-        func notifyWillChange(_ textInput: UITextInput) {
+        func notifyWillChange(_ textInput: any UITextInput) {
             let proxy = IKTextDocumentProxy(input: textInput)
             self.parent.action.notifySomethingWillChange(
                 left: proxy.documentContextBeforeInput ?? "",
@@ -110,7 +110,7 @@ private struct TextViewWrapper: UIViewRepresentable {
             )
         }
 
-        func notifyDidChange(_ textInput: UITextInput) {
+        func notifyDidChange(_ textInput: any UITextInput) {
             let proxy = IKTextDocumentProxy(input: textInput)
             self.parent.action.notifySomethingDidChange(
                 a_left: proxy.documentContextBeforeInput ?? "",
@@ -123,7 +123,7 @@ private struct TextViewWrapper: UIViewRepresentable {
         }
 
         // MARK: こちらで`textWillChange`などをハンドルすることで、`KeyboardViewController`では扱われなくなる
-        func selectionWillChange(_ textInput: UITextInput?) {
+        func selectionWillChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.selectionWillChange")
             guard let textInput else {
                 return
@@ -131,7 +131,7 @@ private struct TextViewWrapper: UIViewRepresentable {
             self.notifyWillChange(textInput)
         }
 
-        func selectionDidChange(_ textInput: UITextInput?) {
+        func selectionDidChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.selectionDidChange")
             guard let textInput else {
                 return
@@ -139,7 +139,7 @@ private struct TextViewWrapper: UIViewRepresentable {
             self.notifyDidChange(textInput)
         }
 
-        func textWillChange(_ textInput: UITextInput?) {
+        func textWillChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.textWillChange")
             guard let textInput else {
                 return
@@ -147,7 +147,7 @@ private struct TextViewWrapper: UIViewRepresentable {
             self.notifyWillChange(textInput)
         }
 
-        func textDidChange(_ textInput: UITextInput?) {
+        func textDidChange(_ textInput: (any UITextInput)?) {
             debug("TextViewWrapper.Coordinator.textDidChange")
             guard let textInput else {
                 return

--- a/Shared/KeyboardView/View/CustomKeybaord/CustomKeyboard.swift
+++ b/Shared/KeyboardView/View/CustomKeybaord/CustomKeyboard.swift
@@ -60,7 +60,7 @@ fileprivate extension CustardInterface {
         }
     }
 
-    var flickKeyModels: [KeyPosition: (model: FlickKeyModelProtocol, width: Int, height: Int)] {
+    var flickKeyModels: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] {
         self.keys.reduce(into: [:]) {dictionary, value in
             switch value.key {
             case let .gridFit(data):
@@ -71,7 +71,7 @@ fileprivate extension CustardInterface {
         }
     }
 
-    var qwertyKeyModels: [KeyPosition: (model: QwertyKeyModelProtocol, sizeType: QwertyKeySizeType)] {
+    var qwertyKeyModels: [KeyPosition: (model: any QwertyKeyModelProtocol, sizeType: QwertyKeySizeType)] {
         self.keys.reduce(into: [:]) {dictionary, value in
             switch value.key {
             case let .gridFit(data):
@@ -126,7 +126,7 @@ fileprivate extension CustardKeyDesign.ColorType {
 }
 
 extension CustardInterfaceKey {
-    var flickKeyModel: FlickKeyModelProtocol {
+    var flickKeyModel: any FlickKeyModelProtocol {
         switch self {
         case let .system(value):
             switch value {
@@ -170,12 +170,12 @@ extension CustardInterfaceKey {
         }
     }
 
-    private func convertToQwertyKeyModel(customKey: KeyFlickSetting.SettingData) -> QwertyKeyModelProtocol {
+    private func convertToQwertyKeyModel(customKey: KeyFlickSetting.SettingData) -> any QwertyKeyModelProtocol {
         let variations = VariationsModel([customKey.flick[.left], customKey.flick[.top], customKey.flick[.right], customKey.flick[.bottom]].compactMap {$0}.map {(label: $0.labelType, actions: $0.pressActions)})
         return QwertyKeyModel(labelType: customKey.labelType, pressActions: customKey.actions, longPressActions: customKey.longpressActions, variationsModel: variations, keyColorType: .normal, needSuggestView: false, for: (1, 1))
     }
 
-    func qwertyKeyModel(layout: CustardInterfaceLayout) -> QwertyKeyModelProtocol {
+    func qwertyKeyModel(layout: CustardInterfaceLayout) -> any QwertyKeyModelProtocol {
         switch self {
         case let .system(value):
             switch value {
@@ -229,7 +229,7 @@ extension CustardInterfaceKey {
         }
     }
 
-    var simpleKeyModel: SimpleKeyModelProtocol {
+    var simpleKeyModel: any SimpleKeyModelProtocol {
         switch self {
         case let .system(value):
             switch value {
@@ -330,7 +330,7 @@ struct CustomKeyboardView: View {
 struct CustardFlickKeysView<Content: View>: View {
     @State private var suggestState = FlickSuggestState()
 
-    init(models: [KeyPosition : (model: FlickKeyModelProtocol, width: Int, height: Int)], tabDesign: TabDependentDesign, layout: CustardInterfaceLayoutGridValue, @ViewBuilder generator: @escaping (FlickKeyView, Int, Int) -> (Content)) {
+    init(models: [KeyPosition : (model: any FlickKeyModelProtocol, width: Int, height: Int)], tabDesign: TabDependentDesign, layout: CustardInterfaceLayoutGridValue, @ViewBuilder generator: @escaping (FlickKeyView, Int, Int) -> (Content)) {
         self.models = models
         self.tabDesign = tabDesign
         self.layout = layout
@@ -338,7 +338,7 @@ struct CustardFlickKeysView<Content: View>: View {
     }
 
     private let contentGenerator: (FlickKeyView, Int, Int) -> (Content)
-    private let models: [KeyPosition: (model: FlickKeyModelProtocol, width: Int, height: Int)]
+    private let models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)]
     private let tabDesign: TabDependentDesign
     private let layout: CustardInterfaceLayoutGridValue
 

--- a/Shared/KeyboardView/View/FlickKeyboard/FlickDataProvider.swift
+++ b/Shared/KeyboardView/View/FlickKeyboard/FlickDataProvider.swift
@@ -89,8 +89,8 @@ struct FlickDataProvider {
     //    )
 
     @KeyboardSetting(.preferredLanguage) private static var preferredLanguage
-    static func TabKeys() -> [FlickKeyModelProtocol] {
-        let first: FlickKeyModelProtocol = {
+    static func TabKeys() -> [any FlickKeyModelProtocol] {
+        let first: any FlickKeyModelProtocol = {
             switch preferredLanguage.first {
             case .el_GR: return FlickChangeKeyboardModel.shared
             case .en_US: return FlickTabKeyModel.abcTabKeyModel
@@ -99,7 +99,7 @@ struct FlickDataProvider {
             }
         }()
 
-        let second: FlickKeyModelProtocol? = {
+        let second: (any FlickKeyModelProtocol)? = {
             guard let second = preferredLanguage.second else {
                 return nil
             }
@@ -134,7 +134,7 @@ struct FlickDataProvider {
         }
     }
     // 縦に並べる
-    var hiraKeyboard: [[FlickKeyModelProtocol]] = [
+    var hiraKeyboard: [[any FlickKeyModelProtocol]] = [
         // 第1列
         Self.TabKeys(),
         // 第2列
@@ -344,7 +344,7 @@ struct FlickDataProvider {
     ]
 
     // 縦に並べる
-    var abcKeyboard: [[FlickKeyModelProtocol]] = [
+    var abcKeyboard: [[any FlickKeyModelProtocol]] = [
         // 第1列
         Self.TabKeys(),
         // 第2列
@@ -504,7 +504,7 @@ struct FlickDataProvider {
 
     ]
     // 縦に並べる
-    var numberKeyboard: [[FlickKeyModelProtocol]] = [
+    var numberKeyboard: [[any FlickKeyModelProtocol]] = [
         // 第1列
         Self.TabKeys(),
         // 第2列

--- a/Shared/KeyboardView/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/Shared/KeyboardView/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -26,7 +26,7 @@ enum KeyPressState {
 }
 
 struct FlickKeyView: View {
-    private let model: FlickKeyModelProtocol
+    private let model: any FlickKeyModelProtocol
 
     @State private var pressState: KeyPressState = .inactive
     @Binding private var suggestState: FlickSuggestState
@@ -40,7 +40,7 @@ struct FlickKeyView: View {
     private let size: CGSize
     private let position: (x: Int, y: Int)
 
-    init(model: FlickKeyModelProtocol, size: CGSize, position: (x: Int, y: Int), suggestState: Binding<FlickSuggestState>) {
+    init(model: any FlickKeyModelProtocol, size: CGSize, position: (x: Int, y: Int), suggestState: Binding<FlickSuggestState>) {
         self.model = model
         self.size = size
         self.position = position

--- a/Shared/KeyboardView/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/Shared/KeyboardView/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -36,7 +36,7 @@ enum QwertyKeyPressState {
 }
 
 struct QwertyKeyView: View {
-    private let model: QwertyKeyModelProtocol
+    private let model: any QwertyKeyModelProtocol
     @EnvironmentObject private var variableStates: VariableStates
 
     @State private var pressState: QwertyKeyPressState = .unpressed
@@ -47,7 +47,7 @@ struct QwertyKeyView: View {
     private let tabDesign: TabDependentDesign
     private let size: CGSize
 
-    init(model: QwertyKeyModelProtocol, tabDesign: TabDependentDesign, size: CGSize) {
+    init(model: any QwertyKeyModelProtocol, tabDesign: TabDependentDesign, size: CGSize) {
         self.model = model
         self.tabDesign = tabDesign
         self.size = size

--- a/Shared/KeyboardView/View/QwertyKeyboard/QwertyDataProvider.swift
+++ b/Shared/KeyboardView/View/QwertyKeyboard/QwertyDataProvider.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 struct QwertyDataProvider {
-    static func tabKeys(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int)) -> (languageKey: QwertyKeyModelProtocol, numbersKey: QwertyKeyModelProtocol, symbolsKey: QwertyKeyModelProtocol, changeKeyboardKey: QwertyKeyModelProtocol) {
+    static func tabKeys(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int)) -> (languageKey: any QwertyKeyModelProtocol, numbersKey: any QwertyKeyModelProtocol, symbolsKey: any QwertyKeyModelProtocol, changeKeyboardKey: any QwertyKeyModelProtocol) {
         @KeyboardSetting(.preferredLanguage) var preferredLanguage
-        let languageKey: QwertyKeyModelProtocol
+        let languageKey: any QwertyKeyModelProtocol
         let first = preferredLanguage.first
         if let second = preferredLanguage.second {
             languageKey = QwertySwitchLanguageKeyModel(rowInfo: rowInfo, languages: (first, second))
@@ -29,10 +29,10 @@ struct QwertyDataProvider {
             languageKey = QwertyFunctionalKeyModel(labelType: .text(first.symbol), rowInfo: rowInfo, pressActions: [.moveTab(targetTab)], longPressActions: .none, needSuggestView: false)
         }
 
-        let numbersKey: QwertyKeyModelProtocol = QwertyFunctionalKeyModel(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.existential(.qwerty_number))], longPressActions: .init(start: [.setTabBar(.toggle)]))
-        let symbolsKey: QwertyKeyModelProtocol = QwertyFunctionalKeyModel(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.existential(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let numbersKey: any QwertyKeyModelProtocol = QwertyFunctionalKeyModel(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.existential(.qwerty_number))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let symbolsKey: any QwertyKeyModelProtocol = QwertyFunctionalKeyModel(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.existential(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
 
-        let changeKeyboardKey: QwertyKeyModelProtocol
+        let changeKeyboardKey: any QwertyKeyModelProtocol
         if let second = preferredLanguage.second {
             changeKeyboardKey = QwertyChangeKeyboardKeyModel(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .secondTab(secondLanguage: second))
         } else {
@@ -47,7 +47,7 @@ struct QwertyDataProvider {
     }
 
     // 横に並べる
-    var numberKeyboard: [[QwertyKeyModelProtocol]] {[
+    var numberKeyboard: [[any QwertyKeyModelProtocol]] {[
         [
             QwertyKeyModel(
                 labelType: .text("1"),
@@ -245,7 +245,7 @@ struct QwertyDataProvider {
     ]
     }
     // 横に並べる
-    var symbolsKeyboard: [[QwertyKeyModelProtocol]] = [
+    var symbolsKeyboard: [[any QwertyKeyModelProtocol]] = [
         [
             QwertyKeyModel(
                 labelType: .text("["),
@@ -467,7 +467,7 @@ struct QwertyDataProvider {
     ]
 
     // 横に並べる
-    var hiraKeyboard: [[QwertyKeyModelProtocol]] = [
+    var hiraKeyboard: [[any QwertyKeyModelProtocol]] = [
         [
             QwertyKeyModel(labelType: .text("q"), pressActions: [.input("q")]),
             QwertyKeyModel(labelType: .text("w"), pressActions: [.input("w")]),
@@ -512,7 +512,7 @@ struct QwertyDataProvider {
     ]
 
     // 横に並べる
-    var abcKeyboard: [[QwertyKeyModelProtocol]] = [
+    var abcKeyboard: [[any QwertyKeyModelProtocol]] = [
         [
             QwertyKeyModel(labelType: .text("q"), pressActions: [.input("q")]),
             QwertyKeyModel(labelType: .text("w"), pressActions: [.input("w")]),

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -2626,6 +2626,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0.3;
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2787,7 +2788,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.0.3;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Swift5.8の`-enable-upcoming-feature ExistentialAny`を適用し、コンパイラがエラーを出すように変更した。
Fix #108