### PR TITLE
[Refactoring] Apply `-enable-upcoming-feature ForwardTrailingClosures`

### DIFF
--- a/MainApp/ContentView.swift
+++ b/MainApp/ContentView.swift
@@ -42,9 +42,9 @@ struct ContentView: View {
                     }
                     .tag(TabSelection.settings)
             }
-            .fullScreenCover(isPresented: $appStates.requireFirstOpenView) {
+            .fullScreenCover(isPresented: $appStates.requireFirstOpenView, content: {
                 EnableAzooKeyView()
-            }
+            })
             .onChange(of: selection) {value in
                 if value == .customize {
                     if ContainerInternalSetting.shared.walkthroughState.shouldDisplay(identifier: .extensions) {
@@ -55,10 +55,10 @@ struct ContentView: View {
             .onOpenURL { url in
                 importFileURL = url
             }
-            .sheet(isPresented: $showWalkthrough) {
+            .sheet(isPresented: $showWalkthrough, content: {
                 CustomizeTabWalkthroughView(isShowing: $showWalkthrough)
                     .background(Color.background)
-            }
+            })
             ForEach(messageManager.necessaryMessages, id: \.id) {data in
                 if messageManager.requireShow(data.id) {
                     switch data.id {

--- a/MainApp/Customize/CustardInformationView.swift
+++ b/MainApp/Customize/CustardInformationView.swift
@@ -155,11 +155,11 @@ struct CustardInformationView: View {
             }
         }
         .navigationBarTitle(Text("カスタムタブの情報"), displayMode: .inline)
-        .sheet(isPresented: self.$showActivityView) {
+        .sheet(isPresented: self.$showActivityView, content: {
             ActivityView(
                 activityItems: [exportedData.url].compactMap {$0},
                 applicationActivities: nil
             )
-        }
+        })
     }
 }

--- a/MainApp/General/Pickers/FontPicker.swift
+++ b/MainApp/General/Pickers/FontPicker.swift
@@ -70,12 +70,12 @@ struct FontPickView: View {
             }
             Text("テキスト Text").font(selectedFont)
         }
-        .sheet(isPresented: $isFontPickerPresented) {
+        .sheet(isPresented: $isFontPickerPresented, content: {
             FontPicker(
                 configuration: .init(),
                 pickerResult: $selectedFont,
                 isPresented: $isFontPickerPresented
             )
-        }
+        })
     }
 }

--- a/MainApp/Theme/ThemeEditView.swift
+++ b/MainApp/Theme/ThemeEditView.swift
@@ -229,11 +229,11 @@ struct ThemeEditView: CancelableEditor {
                     self.theme.pushedKeyFillColor = .color(pushedKeyColor)
                 }
             }
-            .sheet(isPresented: $isSheetPresented) {
+            .sheet(isPresented: $isSheetPresented, content: {
                 PhotoPicker(configuration: self.config,
                             pickerResult: $pickedImage,
                             isPresented: $isSheetPresented)
-            }
+            })
             .navigationBarTitle(Text(self.title), displayMode: .inline)
             .navigationBarBackButtonHidden(true)
             .navigationBarItems(

--- a/MainApp/Theme/ThemeShareView.swift
+++ b/MainApp/Theme/ThemeShareView.swift
@@ -65,14 +65,14 @@ struct ThemeShareView: View {
                 Label("閉じる", systemImage: "xmark")
             }
             .buttonStyle(ShareButtonStyle())
-        }.sheet(isPresented: self.$showActivityView) {
+        }.sheet(isPresented: self.$showActivityView, content: {
             if let image = shareImage.image {
                 ActivityView(
                     activityItems: [TextActivityItem("azooKeyで着せ替えました！", hashtags: ["#azooKey"], links: ["https://apps.apple.com/jp/app/azookey/id1542709230"]), ImageActivityItem(image)],
                     applicationActivities: nil
                 )
             }
-        }
+        })
     }
 
     private func shareOnTwitter() {

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -2626,7 +2626,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0.3;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2788,7 +2788,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.0.3;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Swift 5.8の`-enable-upcoming-feature ForwardTrailingClosures`を適用した。

* trailing closureであり、デフォルト引数があるために省略されていたクロージャがあるようなケースで、明示的なラベルが必要になった。