### PR TITLE
[Bug] 初回の英語タブの利用時に読み込みが遅い問題を修正

### DIFF
--- a/Keyboard/Converter/Converter/Converter.swift
+++ b/Keyboard/Converter/Converter/Converter.swift
@@ -13,6 +13,7 @@ import UIKit
 final class KanaKanjiConverter {
     private var converter = Kana2Kanji()
     private var checker = UITextChecker()
+    private var checkerInitialized: [KeyboardLanguage: Bool] = [.none: true, .ja_JP: true]
 
     // 前回の変換や確定の情報を取っておく部分。
     private var previousInputData: ComposingText?
@@ -26,6 +27,25 @@ final class KanaKanjiConverter {
         self.nodes = []
         self.completedData = nil
         self.lastData = nil
+    }
+
+    func setKeyboardLanguage(_ language: KeyboardLanguage) {
+        if !checkerInitialized[language, default: false] {
+            switch language {
+            case .en_US:
+                Task {
+                    _ = await checker.completions(forPartialWordRange: NSRange(location: 0, length: 1), in: "a", language: "en-US")
+                    checkerInitialized[language] = true
+                }
+            case .el_GR:
+                Task {
+                    _ = await checker.completions(forPartialWordRange: NSRange(location: 0, length: 1), in: "α", language: "el-GR")
+                    checkerInitialized[language] = true
+                }
+            case .none, .ja_JP:
+                checkerInitialized[language] = true
+            }
+        }
     }
 
     /// 上流の関数から`dicdataStore`で行うべき操作を伝播する関数。

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -26,6 +26,7 @@ final class InputManager {
     private var keyboardLanguage: KeyboardLanguage = .ja_JP
     func setKeyboardLanguage(_ value: KeyboardLanguage) {
         self.keyboardLanguage = value
+        self.kanaKanjiConverter.setKeyboardLanguage(value)
     }
 
     /// システム側でproxyを操作した結果、`textDidChange`などがよばれてしまう場合に、その呼び出しをスキップするため、フラグを事前に立てる


### PR DESCRIPTION
UITextCheckerが初回起動時にリソースを読み込む都合で処理に時間がかかるので、タブを開いた時点で前もってリソースを読み込ませることで対応した。
Fix #138 