### PR TITLE
[Bug] キーボードを閉じてすぐに開くとmain proxyが消えてしまう問題を修正

### DIFF
--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -82,7 +82,6 @@ final class DisplayedTextManager {
     }
 
     func closeKeyboard() {
-        self.displayedTextProxy = nil
         self.ikTextFieldProxy = nil
     }
 


### PR DESCRIPTION
`viewWillDisappear`の実行タイミングは、必ずしもその後の`viewWillAppear`より前とは限らない。