### PR TITLE
[Fix] Suppress Type Name Violation in SwiftLint

### DIFF
--- a/MainApp/Tips/Articles/iOS14TerminationNews.swift
+++ b/MainApp/Tips/Articles/iOS14TerminationNews.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+// swiftlint:disable:next type_name
 struct iOS14TerminationNewsView: View {
     internal init(_ readThisMessage: Binding<Bool>) {
         self._readThisMessage = readThisMessage


### PR DESCRIPTION
* ReleaseビルドはViolationをエラーにするが、これが通らなかったので修正