### PR TITLE
[Refactoring] UserDefaultsの"AppleKeyboards"は今後使えなくなるので、UITextInputModeで代替した

### DIFF
--- a/MainApp/MainApp.swift
+++ b/MainApp/MainApp.swift
@@ -11,6 +11,7 @@ import KeyboardViews
 import SwiftUI
 
 final class MainAppStates: ObservableObject {
+    /// キーボードが有効化（キーボードリストに追加）されているかどうかを示す
     @Published var isKeyboardActivated: Bool
     @Published var requireFirstOpenView: Bool
     @Published var japaneseLayout: LanguageLayout = .flick

--- a/MainApp/Utils/checkKeyboardActivation.swift
+++ b/MainApp/Utils/checkKeyboardActivation.swift
@@ -7,14 +7,12 @@
 //
 
 import Foundation
+import class UIKit.UITextInputMode
 import enum AzooKeyUtils.SharedStore
 
 extension SharedStore {
-    static func checkKeyboardActivation() -> Bool {
-        let bundleName = SharedStore.bundleName
-        guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else {
-            return true
-        }
-        return keyboards.contains(bundleName)
+    @MainActor static func checkKeyboardActivation() -> Bool {
+        let keyboards = UITextInputMode.activeInputModes.compactMap {$0.value(forKey: "identifier") as? String}
+        return keyboards.contains(SharedStore.bundleName)
     }
 }


### PR DESCRIPTION
Resolve #237 

* "AppleKeyboards"よりも`UITextInputMode.activeInputModes`の方が更新タイミングが遅い（`onEnterForeground`のタイミングでは更新されていない）ので、taskとして定期実行して動作を再現した。
* 合わせて、UITextInputMode.InputModeDidChangeNotificationによる有効化状態のチェックを追加した