### PR TITLE
[Refactoring] foregroundStyleに移行

### DIFF
--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -14,7 +14,7 @@ let swiftSettings: [SwiftSetting] = [
 ]
 let package = Package(
     name: "AzooKeyCore",
-    platforms: [.iOS(.v14), .macOS(.v11)],
+    platforms: [.iOS(.v15), .macOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
@@ -60,33 +60,33 @@ public struct AzooKeyIcon: View {
         switch looks {
         case .normal:
             Text("1")
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundColor)
         case .king:
             ZStack(alignment: .center) {
                 Text("α")
-                    .foregroundColor(foregroundColor)
+                    .foregroundStyle(foregroundColor)
                 Text("\u{EA00}")
-                    .foregroundColor(.orange)
+                    .foregroundStyle(.orange)
             }
         case .strawHat:
             ZStack(alignment: .center) {
                 Text("β")
-                    .foregroundColor(foregroundColor)
+                    .foregroundStyle(foregroundColor)
                 Text("\u{EA10}")
-                    .foregroundColor(SwiftUI.Color(red: 243 / 255, green: 210 / 255, blue: 82 / 255))
+                    .foregroundStyle(SwiftUI.Color(red: 243 / 255, green: 210 / 255, blue: 82 / 255))
                 Text("\u{EA11}")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
         case .santaClaus:
             ZStack(alignment: .center) {
                 Text("γ")
-                    .foregroundColor(foregroundColor)
+                    .foregroundStyle(foregroundColor)
                 Text("\u{EA20}")
-                    .foregroundColor(.black)
+                    .foregroundStyle(.black)
                 Text("\u{EA21}")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                 Text("\u{EA22}")
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
             }
         }
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
@@ -48,7 +48,7 @@ public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
             let font = Design.fonts.keyLabelFont(text: text, width: width, fontSize: self.textSize, userDecidedSize: keyViewFontSize, layout: variableStates.keyboardLayout, theme: theme)
             Text(text)
                 .font(font)
-                .foregroundColor(mainKeyColor)
+                .foregroundStyle(mainKeyColor)
                 .allowsHitTesting(false)
 
         case let .symbols(symbols):
@@ -62,13 +62,13 @@ public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
                 Text(subText)
                     .font(subFont)
             }
-            .foregroundColor(mainKeyColor)
+            .foregroundStyle(mainKeyColor)
             .allowsHitTesting(false)
 
         case let .image(imageName):
             Image(systemName: imageName)
                 .font(Design.fonts.iconImageFont(keyViewFontSizePreference: Extension.SettingProvider.keyViewFontSize, theme: theme))
-                .foregroundColor(mainKeyColor)
+                .foregroundStyle(mainKeyColor)
                 .allowsHitTesting(false)
 
         case let .customImage(imageName):
@@ -79,7 +79,7 @@ public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
 
         case .changeKeyboard:
             (self.action.makeChangeKeyboardButtonView() as ChangeKeyboardButtonView<Extension>)
-                .foregroundColor(mainKeyColor)
+                .foregroundStyle(mainKeyColor)
 
         case let .selectable(primary, secondery):
             let font = Design.fonts.keyLabelFont(text: primary + primary, width: width, fontSize: self.textSize, userDecidedSize: keyViewFontSize, layout: variableStates.keyboardLayout, theme: theme)
@@ -89,10 +89,10 @@ public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
                 Text(primary)
                     .font(font)
                     .padding(.trailing, -5)
-                    .foregroundColor(mainKeyColor)
+                    .foregroundStyle(mainKeyColor)
                 Text(secondery)
                     .font(subFont.bold())
-                    .foregroundColor(.gray)
+                    .foregroundStyle(.gray)
                     .padding(.leading, -5)
                     .offset(y: -1)
             }.allowsHitTesting(false)

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/MessageView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/MessageView.swift
@@ -89,11 +89,11 @@ struct MessageView<ID: MessageIdentifierProtocol>: View {
                         Text(data.title)
                             .font(.title.bold())
                             .padding(.top)
-                            .foregroundColor(.black)
+                            .foregroundStyle(.black)
                         ScrollView {
                             Text(data.description)
                                 .padding(.horizontal)
-                                .foregroundColor(.black)
+                                .foregroundStyle(.black)
                                 .lineLimit(nil)
                                 .fixedSize(horizontal: false, vertical: true)
                         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -233,7 +233,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     .frame(width: r, height: r)
                     .overlay(
                         Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
                     )
                     .gesture(moveGesture)
@@ -254,7 +254,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                         .frame(width: r, height: r)
                         .overlay(
                             Image(systemName: "arrow.triangle.2.circlepath")
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                                 .font(Font.system(size: r * 0.5))
                         )
                 }
@@ -270,7 +270,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                         .frame(width: r, height: r)
                         .overlay(
                             Image(systemName: "checkmark")
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                                 .font(Font.system(size: r * 0.5))
                         )
                 }
@@ -333,7 +333,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: r, height: r)
                     .overlay(
                         Image(systemName: "aspectratio")
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
                     )
             }
@@ -347,7 +347,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: r, height: r)
                     .overlay(
                         Image(systemName: "arrow.up.backward.and.arrow.down.forward")
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
                     )
             }
@@ -370,7 +370,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: r, height: r)
                     .overlay(
                         Image(systemName: "arrow.triangle.2.circlepath")
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
                     )
             }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/TemporalMessageView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/TemporalMessageView.swift
@@ -9,7 +9,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 15, *)
 struct TemporalMessageView: View {
     let message: TemporalMessage
     let onDismiss: () -> Void
@@ -22,7 +21,7 @@ struct TemporalMessageView: View {
         case .auto:
             Text(message.title)
                 .bold()
-                .foregroundColor(.black)
+                .foregroundStyle(.black)
                 .onAppear {
                     Task {
                         // 1.5秒待機してからdismissを実行する
@@ -34,7 +33,7 @@ struct TemporalMessageView: View {
             VStack {
                 Text(message.title)
                     .bold()
-                    .foregroundColor(.black)
+                    .foregroundStyle(.black)
                 Button("OK", action: onDismiss)
             }
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -253,7 +253,6 @@ extension CustardInterfaceKey {
     }
 }
 
-@available(iOS 15, *)
 struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let custard: Custard
     private var tabDesign: TabDependentDesign {
@@ -322,7 +321,6 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
     }
 }
 
-@available(iOS 15, *)
 public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExtension, Content: View>: View {
     @State private var suggestState = FlickSuggestState()
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
@@ -10,7 +10,6 @@ import CustardKit
 import Foundation
 import SwiftUI
 
-@available(iOS 15, *)
 struct FlickKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @State private var suggestState = FlickSuggestState()
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 import SwiftUIUtils
 
-@available(iOS 15, *)
 struct EmojiTabResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     init() {}
     @Environment(Extension.Theme.self) private var theme
@@ -112,7 +111,7 @@ struct EmojiTabResultBarButtonStyle<Extension: ApplicationSpecificKeyboardViewEx
         configuration.label
             .font(Design.fonts.resultViewFont(theme: theme, userSizePrefrerence: self.userSizePrefrerence, fontSize: height * 0.9))
             .frame(height: height)
-            .foregroundColor(theme.resultTextColor.color) // 文字色は常に不透明度1で描画する
+            .foregroundStyle(theme.resultTextColor.color) // 文字色は常に不透明度1で描画する
             .background(
                 configuration.isPressed ?
                     theme.pushedKeyFillColor.color.opacity(0.5) :

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 import SwiftUIUtils
 
-@available(iOS 15, *)
 struct KeyboardBarView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @Binding private var isResultViewExpanded: Bool
@@ -81,7 +80,7 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
                 case let .systemImage(name):
                     Image(systemName: name)
                         .frame(width: iconSize, height: iconSize)
-                        .foregroundColor(buttonLabelColor)
+                        .foregroundStyle(buttonLabelColor)
                 }
             }
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/MoveCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/MoveCursorBar.swift
@@ -208,7 +208,7 @@ struct MoveCursorBarBeta<Extension: ApplicationSpecificKeyboardViewExtension>: V
             }
         }
         .allowsHitTesting(false)
-        .foregroundColor(theme.resultTextColor.color.opacity(0.4))
+        .foregroundStyle(theme.resultTextColor.color.opacity(0.4))
         .drawingGroup()
         .frame(width: viewWidth)
         .clipped()
@@ -221,7 +221,7 @@ struct MoveCursorBarBeta<Extension: ApplicationSpecificKeyboardViewExtension>: V
 
                 Image(systemName: "chevron.left.2")
                     .font(symbolFont(size: 18))
-                    .foregroundColor(symbolsColor)
+                    .foregroundStyle(symbolsColor)
                     .padding()
                     .overlay(
                         TouchDownAndTouchUpGestureView {
@@ -242,12 +242,12 @@ struct MoveCursorBarBeta<Extension: ApplicationSpecificKeyboardViewExtension>: V
                 Spacer()
                 Text(verbatim: "│")
                     .font(.system(size: fontSize + 4))
-                    .foregroundColor(symbolsColor)
+                    .foregroundStyle(symbolsColor)
                     .allowsHitTesting(false)
                 Spacer()
                 Image(systemName: "chevron.right.2")
                     .font(symbolFont(size: 18))
-                    .foregroundColor(symbolsColor)
+                    .foregroundStyle(symbolsColor)
                     .padding()
                     .overlay(
                         TouchDownAndTouchUpGestureView {
@@ -365,7 +365,7 @@ struct MoveCursorBar<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                                 .padding()
                         })
                         Spacer()
-                    }.foregroundColor(symbolsColor))
+                    }.foregroundStyle(symbolsColor))
             }
         }
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
@@ -201,7 +201,7 @@ struct ResultButtonStyle<Extension: ApplicationSpecificKeyboardViewExtension>: B
             .font(Design.fonts.resultViewFont(theme: theme, userSizePrefrerence: self.userSizePreference))
             .frame(height: height)
             .padding(.all, 5)
-            .foregroundColor(theme.resultTextColor.color) // 文字色は常に不透明度1で描画する
+            .foregroundStyle(theme.resultTextColor.color) // 文字色は常に不透明度1で描画する
             .background(
                 configuration.isPressed ?
                     theme.pushedKeyFillColor.color.opacity(0.5) :

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -9,7 +9,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 15, *)
 public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @State private var messageManager = MessageManager(necessaryMessages: Extension.MessageProvider.messages, userDefaults: Extension.MessageProvider.userDefaults)
     @State private var isResultViewExpanded = false

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
@@ -30,7 +30,7 @@ struct QwertyVariationsView<Extension: ApplicationSpecificKeyboardViewExtension>
             ForEach(model.variations.indices, id: \.self) {(index: Int) in
                 ZStack {
                     Rectangle()
-                        .foregroundColor(index == selection ? Color.blue : suggestColor)
+                        .foregroundStyle(index == selection ? Color.blue : suggestColor)
                         .frame(width: tabDesign.keyViewWidth, height: tabDesign.keyViewHeight * 0.9, alignment: .center)
                         .cornerRadius(10.0)
                     getLabel(model.variations[index].label)

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
@@ -47,7 +47,6 @@ private final class ClipboardHistory: ObservableObject {
     }
 }
 
-@available(iOS 15, *)
 struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @StateObject private var target = ClipboardHistory()
@@ -72,7 +71,7 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
                         if pinned {
                             HStack {
                                 Image(systemName: "pin.circle.fill")
-                                    .foregroundColor(.orange)
+                                    .foregroundStyle(.orange)
                                 Text(string)
                                     .lineLimit(2)
                             }
@@ -225,7 +224,7 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
             }
         }
         .font(Design.fonts.resultViewFont(theme: theme, userSizePrefrerence: Extension.SettingProvider.resultViewFontSize))
-        .foregroundColor(theme.resultTextColor.color)
+        .foregroundStyle(theme.resultTextColor.color)
         .onAppear {
             self.target.reload(manager: variableStates.clipboardHistoryManager)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -293,7 +293,7 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
             Label(genre.title, systemImage: systemImage)
                 .labelStyle(.iconOnly)
                 .font(.largeTitle)
-                .foregroundColor(theme.resultTextColor.color)
+                .foregroundStyle(theme.resultTextColor.color)
                 .frame(width: footerHeight, height: scrollViewHeight)
                 .contentShape(Rectangle())
         }

--- a/AzooKeyCore/Sources/SwiftUIUtils/Availability.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/Availability.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 
 public extension View {
-    @available(iOS 15, macOS 12, *)
     @ViewBuilder
     func iOS16_scrollContentBackground(_ visibility: Visibility) -> some View {
         if #available(iOS 16, macOS 13, *) {

--- a/AzooKeyCore/Sources/SwiftUIUtils/Color.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/Color.swift
@@ -21,6 +21,20 @@ public extension Color {
     static let background = Color(UIColor.systemBackground)
     static let label = Color(UIColor.label)
 }
+
+public extension ShapeStyle where Self == Color {
+    static var accentColor: Self { .accentColor }
+    static var systemGray: Self { .systemGray }
+    static var systemGray2: Self { .systemGray2 }
+    static var systemGray3: Self { .systemGray3 }
+    static var systemGray4: Self { .systemGray4 }
+    static var systemGray5: Self { .systemGray5 }
+    static var systemGray6: Self { .systemGray6 }
+    static var background: Self { .background }
+    static var secondarySystemBackground: Self { .secondarySystemBackground }
+    static var label: Self { .label }
+}
+
 #elseif os(macOS)
 import AppKit
 public extension Color {

--- a/AzooKeyCore/Sources/SwiftUIUtils/IntegerTextField.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/IntegerTextField.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, *)
 public struct IntegerTextField: View {
     public init(_ title: LocalizedStringKey, text: Binding<String>, range: ClosedRange<Int> = .min ... .max) {
         self.title = title

--- a/AzooKeyCore/Sources/SwiftUIUtils/StringInterpolation.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/StringInterpolation.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 import SwiftUI
+
+// TODO: in iOS 17, Text.foregroundColor is deprecated. Use Text.foregroundStyle instead.
 public extension LocalizedStringKey.StringInterpolation {
     mutating func appendInterpolation(_ value: LocalizedStringKey, color: Color? = nil) {
         self.appendInterpolation(Text(value).foregroundColor(color))

--- a/MainApp/ContentView.swift
+++ b/MainApp/ContentView.swift
@@ -114,7 +114,7 @@ private struct TabItem: View {
     var body: some View {
         VStack {
             Image(systemName: systemImage).font(.system(size: 20, weight: .light))
-                .foregroundColor(.systemGray2)
+                .foregroundStyle(.systemGray2)
             Text(title)
         }
     }

--- a/MainApp/Customize/CodableActionDataEditor.swift
+++ b/MainApp/Customize/CodableActionDataEditor.swift
@@ -554,6 +554,6 @@ private struct ActionPicker: View {
                 }
             }
         }
-        .foregroundColor(.primary)
+        .foregroundStyle(.primary)
     }
 }

--- a/MainApp/Customize/CustardInformationView.swift
+++ b/MainApp/Customize/CustardInformationView.swift
@@ -120,10 +120,10 @@ struct CustardInformationView: View {
                     switch userdata {
                     case let .gridScroll(value):
                         NavigationLink("編集する", destination: EditingScrollCustardView(manager: $manager, editingItem: value))
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(.accentColor)
                     case let .tenkey(value):
                         NavigationLink("編集する", destination: EditingTenkeyCustardView(manager: $manager, editingItem: value))
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(.accentColor)
                     }
                 }
             }

--- a/MainApp/Customize/CustardInterfaceKeyEditor.swift
+++ b/MainApp/Customize/CustardInterfaceKeyEditor.swift
@@ -466,7 +466,7 @@ struct CustardInterfaceKeyEditor: View {
             Section {
                 Button("リセット") {
                     key = .custom(.empty)
-                }.foregroundColor(.red)
+                }.foregroundStyle(.red)
             }
         }
     }
@@ -503,7 +503,7 @@ struct CustardInterfaceKeyEditor: View {
                     Button("入力を設定する") {
                         key[.custom][.inputAction, position] = ""
                     }
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
                 }
             }
             Section(header: Text("ラベル")) {
@@ -574,12 +574,12 @@ struct CustardInterfaceKeyEditor: View {
             Section(header: Text("アクション")) {
                 Text("キーを押したときの動作をより詳しく設定します。")
                 NavigationLink("アクションを編集する", destination: CodableActionDataEditor($key[.custom][.pressAction, position], availableCustards: CustardManager.load().availableCustards))
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
             }
             Section(header: Text("長押しアクション")) {
                 Text("キーを長押ししたときの動作をより詳しく設定します。")
                 NavigationLink("長押しアクションを編集する", destination: CodableLongpressActionDataEditor($key[.custom][.longpressAction, position], availableCustards: CustardManager.load().availableCustards))
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
             }
 
             if position == .center {
@@ -592,7 +592,7 @@ struct CustardInterfaceKeyEditor: View {
                 Section {
                     Button("リセット") {
                         key = .custom(.empty)
-                    }.foregroundColor(.red)
+                    }.foregroundStyle(.red)
                 }
             }
             if let direction = position.flickDirection {
@@ -600,7 +600,7 @@ struct CustardInterfaceKeyEditor: View {
                     key[.custom].variations.removeAll {
                         $0.type == .flickVariation(direction)
                     }
-                }.foregroundColor(.red)
+                }.foregroundStyle(.red)
             }
         }
     }

--- a/MainApp/Customize/CustomizeTabView.swift
+++ b/MainApp/Customize/CustomizeTabView.swift
@@ -23,7 +23,7 @@ struct CustomizeTabView: View {
                             .listRowSeparator(.hidden, edges: .bottom)
                         Text("好きな文字や文章を並べたオリジナルのタブを作成することができます。")
                         NavigationLink("カスタムタブの管理", destination: ManageCustardView(manager: $appStates.custardManager))
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(.accentColor)
                     }
 
                     Section(header: Text("タブバー")) {
@@ -41,7 +41,7 @@ struct CustomizeTabView: View {
                         }
                         BoolSettingView(.displayTabBarButton)
                         NavigationLink("タブバーを編集", destination: EditingTabBarView(manager: $appStates.custardManager))
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(.accentColor)
                     }
 
                     Section(header: Text("カスタムキー")) {

--- a/MainApp/Customize/CustomizeTabWalkthrough.swift
+++ b/MainApp/Customize/CustomizeTabWalkthrough.swift
@@ -65,12 +65,12 @@ struct CustomizeTabWalkthroughView: View {
                                 Image(systemName: item.image)
                                     .font(imagesFont)
                                     .frame(width: geometry.size.width / 7.0, height: geometry.size.width / 7.0)
-                                    .foregroundColor(.blue)
+                                    .foregroundStyle(.blue)
                                 VStack(alignment: .leading) {
                                     Text(item.headline)
                                         .font(.subheadline.bold())
                                     Text(item.body)
-                                        .foregroundColor(.gray)
+                                        .foregroundStyle(.gray)
                                         .font(.subheadline)
                                 }
                             }
@@ -83,7 +83,7 @@ struct CustomizeTabWalkthroughView: View {
                             isShowing = false
                         }
                         .buttonStyle(LargeButtonStyle(backgroundColor: .blue))
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .padding(.top, 30)
                     }
                     .background(Color.background)

--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -63,7 +63,7 @@ struct EditingTabBarView: View {
                         Label("アクション", systemImage: "terminal")
 
                         Text(makeLabelText(item: item))
-                            .foregroundColor(.gray)
+                            .foregroundStyle(.gray)
                     }
                 } label: { item in
                     label(labelType: item.label)

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -162,7 +162,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
                                         )
                                         .overlay(
                                             Image(systemName: "plus.circle")
-                                                .foregroundColor(.accentColor)
+                                                .foregroundStyle(.accentColor)
                                         )
                                 }
                             }
@@ -277,19 +277,19 @@ struct EditingTenkeyCustardView: CancelableEditor {
                                     editingItem.emptyKeys.insert(.gridFit(x: x, y: y))
                                 } label: {
                                     Label("削除する", systemImage: "trash")
-                                        .foregroundColor(.red)
+                                        .foregroundStyle(.red)
                                 }
                                 Button(role: .destructive) {
                                     removeRow(y: y)
                                 } label: {
                                     Label("この行を削除", systemImage: "trash")
-                                        .foregroundColor(.red)
+                                        .foregroundStyle(.red)
                                 }
                                 Button(role: .destructive) {
                                     removeColumn(x: x)
                                 } label: {
                                     Label("この列を削除", systemImage: "trash")
-                                        .foregroundColor(.red)
+                                        .foregroundStyle(.red)
                                 }
                             }
                         }

--- a/MainApp/Customize/ManageCustardView.swift
+++ b/MainApp/Customize/ManageCustardView.swift
@@ -191,10 +191,10 @@ struct ManageCustardView: View {
             Section(header: Text("作る")) {
                 Text("登録したい文字や単語を順番に書いていくだけでスクロール式のカスタムタブを作成することができます。")
                 NavigationLink("スクロール式のカスタムタブを作る", destination: EditingScrollCustardView(manager: $manager))
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
                 Text("フリック式のカスタムタブを作成することができます。")
                 NavigationLink("フリック式のカスタムタブを作る", destination: EditingTenkeyCustardView(manager: $manager))
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
             }
             if let custards = data.custards {
                 ForEach(custards, id: \.identifier) {custard in
@@ -219,7 +219,7 @@ struct ManageCustardView: View {
                     selectedDocument = Data()
                     data.reset()
                 }
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
 
             } else {
                 Section(header: Text("おすすめ")) {
@@ -229,7 +229,7 @@ struct ManageCustardView: View {
                                 data.download(from: "https://azookey.netlify.app/static/custard/\(item.file)")
                             } label: {
                                 Image(systemName: "square.and.arrow.down")
-                                    .foregroundColor(.accentColor)
+                                    .foregroundStyle(.accentColor)
                                     .padding(.horizontal, 5)
                             }
                             Text(verbatim: item.name)
@@ -263,7 +263,7 @@ struct ManageCustardView: View {
                 if let failure = data.failureData {
                     HStack {
                         Image(systemName: "exclamationmark.triangle")
-                        Text(failure.description).foregroundColor(.red)
+                        Text(failure.description).foregroundStyle(.red)
                     }
                 }
                 Section {
@@ -406,7 +406,7 @@ struct URLImportCustardView: View {
                     data.reset()
                     url = nil
                 }
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
             } else if let text = data.processState.description {
                 Section(header: Text("読み込み中")) {
                     ProgressView(text)
@@ -414,21 +414,21 @@ struct URLImportCustardView: View {
                         data.reset()
                         url = nil
                     }
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
                 }
             } else {
                 Section(header: Text("読み込み失敗")) {
                     if let failure = data.failureData {
                         HStack {
                             Image(systemName: "exclamationmark.triangle")
-                            Text(failure.description).foregroundColor(.red)
+                            Text(failure.description).foregroundStyle(.red)
                         }
                     }
                     Button("閉じる") {
                         data.reset()
                         url = nil
                     }
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
                 }
             }
         }

--- a/MainApp/EnableAzooKeyView/EnableAzooKeyViewComponent.swift
+++ b/MainApp/EnableAzooKeyView/EnableAzooKeyViewComponent.swift
@@ -75,7 +75,7 @@ struct EnableAzooKeyViewButton: View {
                 }
             }
             .buttonStyle(LargeButtonStyle(backgroundColor: .blue))
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
         case .destructive:
             Button(action: action) {
                 if let systemName {
@@ -84,7 +84,7 @@ struct EnableAzooKeyViewButton: View {
                     Text(text)
                 }
             }
-            .foregroundColor(.red)
+            .foregroundStyle(.red)
         }
     }
 }

--- a/MainApp/General/DisclosuringList.swift
+++ b/MainApp/General/DisclosuringList.swift
@@ -91,7 +91,7 @@ private struct MiniDisclosureGroup<Label: View, Content: View>: View {
             } label: {
                 Image(systemName: hidden ? "chevron.right" : "chevron.down")
                     .font(.system(.caption).bold())
-                    .foregroundColor(.accentColor)
+                    .foregroundStyle(.accentColor)
             }
         }
         if !hidden {

--- a/MainApp/General/DraggableView.swift
+++ b/MainApp/General/DraggableView.swift
@@ -33,7 +33,7 @@ struct DraggableView<Content: View, Collection: BidirectionalCollection & Random
     private var separator: some View {
         Rectangle()
             .frame(width: 2, height: height * 0.9)
-            .foregroundColor(.accentColor)
+            .foregroundStyle(.accentColor)
     }
 
     var body: some View {

--- a/MainApp/General/HeaderLogoView.swift
+++ b/MainApp/General/HeaderLogoView.swift
@@ -32,7 +32,7 @@ struct HeaderLogoView: View {
                     .font(Font(UIFont.systemFont(ofSize: iconSize)))
             }
         }
-        .foregroundColor(iconColor)
+        .foregroundStyle(iconColor)
         .padding(.top, 5)
         .padding(.bottom, -5)
     }

--- a/MainApp/General/PasteButton.swift
+++ b/MainApp/General/PasteButton.swift
@@ -41,6 +41,6 @@ struct PasteLongPressButton: View {
                     text = string
                 }
             }
-            .foregroundColor(.accentColor)
+            .foregroundStyle(.accentColor)
     }
 }

--- a/MainApp/Setting/AdditionalDict/AzooKeyUserDictionary.swift
+++ b/MainApp/Setting/AdditionalDict/AzooKeyUserDictionary.swift
@@ -100,10 +100,10 @@ private struct UserDictionaryDataListView: View {
                             } label: {
                                 HStack {
                                     Text(data.word)
-                                        .foregroundColor(.primary)
+                                        .foregroundStyle(.primary)
                                     Spacer()
                                     Text(data.ruby)
-                                        .foregroundColor(.systemGray)
+                                        .foregroundStyle(.systemGray)
                                 }
                             }
                             .contextMenu {
@@ -222,7 +222,7 @@ private struct UserDictionaryDataEditor: CancelableEditor {
                             selectedTemplate = (String(parsedWords[i].dropFirst(2).dropLast(2)), i)
                         } label: {
                             Text(parsedWords[i])
-                                .foregroundColor(.primary)
+                                .foregroundStyle(.primary)
                                 .padding(0)
                                 .background(Color.orange.opacity(0.7).cornerRadius(5))
                         }

--- a/MainApp/Setting/BooleanSetting/BoolSettingView.swift
+++ b/MainApp/Setting/BooleanSetting/BoolSettingView.swift
@@ -34,7 +34,7 @@ struct BoolSettingView<SettingKey: BoolKeyboardSettingKey>: View {
                 }
                 if SettingKey.requireFullAccess {
                     Image(systemName: "f.circle.fill")
-                        .foregroundColor(.purple)
+                        .foregroundStyle(.purple)
                 }
             }
         }

--- a/MainApp/Setting/CustomKeys/FlickCustomKeys/FlickCustomKeySettingView.swift
+++ b/MainApp/Setting/CustomKeys/FlickCustomKeys/FlickCustomKeySettingView.swift
@@ -170,7 +170,7 @@ struct FlickCustomKeySettingView<SettingKey: FlickCustomKeyKeyboardSetting>: Vie
                                     Button("入力を設定する") {
                                         setting.value[.input, selectedPosition] = ""
                                     }
-                                    .foregroundColor(.accentColor)
+                                    .foregroundStyle(.accentColor)
                                 }
                             }
                         case .tab:
@@ -201,22 +201,22 @@ struct FlickCustomKeySettingView<SettingKey: FlickCustomKeyKeyboardSetting>: Vie
                         Section(header: Text("アクション")) {
                             Text("キーを押したときの動作をより詳しく設定します。")
                             NavigationLink("アクションを編集する", destination: CodableActionDataEditor($setting.value[keyPath: selectedPosition.bindedKeyPath].actions, availableCustards: CustardManager.load().availableCustards))
-                                .foregroundColor(.accentColor)
+                                .foregroundStyle(.accentColor)
                         }
                         Section(header: Text("長押しアクション")) {
                             Text("キーを長押ししたときの動作をより詳しく設定します。")
                             NavigationLink("長押しアクションを編集する", destination: CodableLongpressActionDataEditor($setting.value[keyPath: selectedPosition.bindedKeyPath].longpressActions, availableCustards: CustardManager.load().availableCustards))
-                                .foregroundColor(.accentColor)
+                                .foregroundStyle(.accentColor)
                         }
                         Button("リセット") {
                             self.reload()
                         }
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                     } else {
                         Text("このキーは編集できません")
                     }
                 }
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
             }
         }
     }
@@ -226,7 +226,7 @@ struct FlickCustomKeySettingView<SettingKey: FlickCustomKeyKeyboardSetting>: Vie
         Button("タブを設定する") {
             setting.value[keyPath: keyPath].actions = [.moveTab(.system(.user_japanese))]
         }
-        .foregroundColor(.accentColor)
+        .foregroundStyle(.accentColor)
     }
 
     @MainActor private func isPossiblePosition(_ position: FlickKeyPosition) -> Bool {

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/CustomKeysSettingView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/CustomKeysSettingView.swift
@@ -14,13 +14,13 @@ struct CustomKeysSettingView: View {
             .listRowSeparator(.hidden, edges: .bottom)
         Text("「小ﾞﾟ」キーと「､｡?!」キーで入力する文字をカスタマイズすることができます。")
         NavigationLink("設定する", destination: FlickCustomKeysSettingSelectView())
-            .foregroundColor(.accentColor)
+            .foregroundStyle(.accentColor)
             .listRowSeparator(.visible, edges: .all)
         ImageSlideshowView(pictures: ["qwertyCustomKeySetting0", "qwertyCustomKeySetting1", "qwertyCustomKeySetting2"])
             .listRowSeparator(.hidden, edges: .bottom)
         Text("数字タブの青枠部分に好きな記号や文字を割り当てられます。")
         NavigationLink("設定する", destination: QwertyCustomKeysSettingView(.numberTabCustomKeys))
-            .foregroundColor(.accentColor)
+            .foregroundStyle(.accentColor)
             .listRowSeparator(.visible, edges: .all)
     }
 }

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -222,7 +222,7 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                                 Button("入力を設定する") {
                                     setting.value[.input, selection] = ""
                                 }
-                                .foregroundColor(.accentColor)
+                                .foregroundStyle(.accentColor)
                             }
                         }
                         Section(header: Text("ラベル")) {
@@ -234,7 +234,7 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                         Section(header: Text("アクション")) {
                             Text("キーを押したときの動作をより詳しく設定します。")
                             NavigationLink("アクションを編集する", destination: CodableActionDataEditor(binded[selection].actions, availableCustards: CustardManager.load().availableCustards))
-                                .foregroundColor(.accentColor)
+                                .foregroundStyle(.accentColor)
                         }
                         Button("削除") {
                             bottomSheetShown = false
@@ -253,7 +253,7 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                                 }
                             }
                         }
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     } else {
                         Button("キーを追加する") {
                             self.addPressKey()

--- a/MainApp/Setting/MemoryResetSetting/MemoryResetSetting.swift
+++ b/MainApp/Setting/MemoryResetSetting/MemoryResetSetting.swift
@@ -16,7 +16,7 @@ struct MemoryResetSettingItemView: View {
         Button("学習のリセット") {
             self.showAlert = true
         }
-        .foregroundColor(.red)
+        .foregroundStyle(.red)
         .alert(isPresented: $showAlert) {
             Alert(
                 title: Text("学習履歴をリセットします。よろしいですか？"),

--- a/MainApp/Setting/SettingTab.swift
+++ b/MainApp/Setting/SettingTab.swift
@@ -119,9 +119,9 @@ struct SettingTabView: View {
                 Section(header: Text("このアプリについて")) {
                     NavigationLink("お問い合わせ", destination: ContactView())
                     FallbackLink("プライバシーポリシー", destination: URL(string: "https://azookey.netlify.app/PrivacyPolicy")!)
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                     FallbackLink("利用規約", destination: URL(string: "https://azookey.netlify.app/TermsOfService")!)
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                     NavigationLink("更新履歴", destination: UpdateInformationView())
                     HStack {
                         Text("URL Scheme")

--- a/MainApp/Setting/Template/TemplateEditingView.swift
+++ b/MainApp/Setting/Template/TemplateEditingView.swift
@@ -52,7 +52,7 @@ struct TemplateEditingView: CancelableEditor {
                 }
                 if case let .nameError(message) = validation() {
                     Label(message, systemImage: "exclamationmark.triangle")
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                 }
             }
         }

--- a/MainApp/Setting/Template/TemplateListView.swift
+++ b/MainApp/Setting/Template/TemplateListView.swift
@@ -46,7 +46,7 @@ struct TemplateListView: View {
                                 Text(value.item.name)
                                 Spacer()
                                 Text(value.item.previewString)
-                                    .foregroundColor(.gray)
+                                    .foregroundStyle(.gray)
                             }
                         }
                     }

--- a/MainApp/Theme/ThemeEditView.swift
+++ b/MainApp/Theme/ThemeEditView.swift
@@ -146,7 +146,7 @@ struct ThemeEditView: CancelableEditor {
                                 pickedImage = nil
                                 trimmedImage = nil
                             }
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                         } else {
                             Button("\(systemImage: "photo")画像を選ぶ") {
                                 self.isSheetPresented = true
@@ -183,7 +183,7 @@ struct ThemeEditView: CancelableEditor {
                             self.trimmedImage = nil
                             self.theme = self.base
                         }
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                     }
                 }
                 let tab: Tab.ExistentialTab = {

--- a/MainApp/Theme/ThemeShareView.swift
+++ b/MainApp/Theme/ThemeShareView.swift
@@ -157,9 +157,9 @@ private struct ShareButtonStyle: ButtonStyle {
         configuration
             .label
             .font(.body.bold())
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .padding()
-            .background(RoundedRectangle(cornerRadius: 3).foregroundColor(.blue))
+            .background(RoundedRectangle(cornerRadius: 3).foregroundStyle(.blue))
             .padding()
     }
 }

--- a/MainApp/Theme/ThemeTab.swift
+++ b/MainApp/Theme/ThemeTab.swift
@@ -38,7 +38,7 @@ struct ThemeTabView: View {
             .overlay(
                 Image(systemName: systemName)
                     .font(Font.system(size: width / 2).weight(.bold))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             )
     }
 
@@ -133,7 +133,7 @@ struct ThemeTabView: View {
                         manager.remove(index: index)
                     } label: {
                         Label("削除する", systemImage: "trash")
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                     }
                     .disabled(index == 0)
                 }
@@ -150,7 +150,7 @@ struct ThemeTabView: View {
                             editViewIndex = nil
                             editViewEnabled = true
                         }
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                         if editViewIndex == nil {
                             NavigationLink(destination: ThemeEditView(index: editViewIndex, manager: $manager), isActive: $editViewEnabled) {
                                 EmptyView()

--- a/MainApp/Tips/TipsView.swift
+++ b/MainApp/Tips/TipsView.swift
@@ -32,7 +32,7 @@ struct TipsTabView: View {
                             HStack {
                                 if !readArticle_iOS14_service_termination {
                                     Image(systemName: "exclamationmark.circle.fill")
-                                        .foregroundColor(.red)
+                                        .foregroundStyle(.red)
                                 }
                                 NavigationLink("iOS14のサポートを終了します", destination: iOS14TerminationNewsView($readArticle_iOS14_service_termination))
                             }


### PR DESCRIPTION
Resolve #214 

* foregroundColorがiOS17以降deprecatedなのでforegroundStyleに移行
* AzooKeyCoreのminimum os versionを変更
* Colorを追加