### PR TITLE
[Feature] シフトキーの実装を追加

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyKeyboardViewExtension.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyKeyboardViewExtension.swift
@@ -93,6 +93,10 @@ public enum AzooKeyKeyboardViewExtension: ApplicationSpecificKeyboardViewExtensi
     public static var useBetaMoveCursorBar: Bool {
         UseBetaMoveCursorBar.value
     }
+    
+    public static var useShiftKey: Bool {
+        false
+    }
 
     public static var canResetLearningForCandidate: Bool {
         LearningTypeSetting.value.needUsingMemory

--- a/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewSettingProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewSettingProvider.swift
@@ -31,6 +31,7 @@ import Foundation
     static var displayTabBarButton: Bool { get }
     static var hideResetButtonInOneHandedMode: Bool { get }
     static var useBetaMoveCursorBar: Bool { get }
+    static var useShiftKey: Bool { get }
 
     static var canResetLearningForCandidate: Bool { get }
 

--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -45,8 +45,10 @@ public final class VariableStates: ObservableObject {
         var isTextMagnifying = false
         var hasUpsideComponent = false
         public var isCapsLocked = false
+        public var isShifted = false
 
         static let isCapsLockedKey = "isCapsLocked"
+        public static let isShiftedKey = "isShifted"
         static let hasUpsideComponentKey = "is_screen_expanded"
         static let hasFullAccessKey = "has_full_access"
         // ビルトインのステートとカスタムのステートの両方を適切に扱いたい
@@ -80,6 +82,8 @@ public final class VariableStates: ObservableObject {
                     return SemiStaticStates.shared.hasFullAccess
                 } else if key == Self.isCapsLockedKey {
                     return self.isCapsLocked
+                } else if key == Self.isShiftedKey {
+                    return self.isShifted
                 } else if key == Self.hasUpsideComponentKey {
                     return self.hasUpsideComponent
                 }
@@ -92,7 +96,11 @@ public final class VariableStates: ObservableObject {
                         return
                     } else if key == "isTextMagnifying" {
                         self.isTextMagnifying = newValue
+                    } else if key == Self.isShiftedKey {
+                        self.isCapsLocked = self.isCapsLocked && !newValue
+                        self.isShifted = newValue
                     } else if key == Self.isCapsLockedKey {
+                        self.isShifted = self.isShifted && !newValue
                         self.isCapsLocked = newValue
                     } else {
                         custardStates[key] = newValue

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
@@ -32,7 +32,7 @@ struct QwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qwer
     }
 
     func label<Extension: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
-        if states.boolStates.isCapsLocked, states.keyboardLanguage == .en_US, case let .text(text) = self.labelType {
+        if (states.boolStates.isCapsLocked || states.boolStates.isShifted), states.keyboardLanguage == .en_US, case let .text(text) = self.labelType {
             return KeyLabel(.text(text.uppercased()), width: width, textColor: color)
         }
         return KeyLabel(self.labelType, width: width, textColor: color)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
@@ -1,0 +1,56 @@
+//
+//  QwertyShiftKeyModel.swift
+//  
+//
+//  Created by ensan on 2023/08/11.
+//
+
+import SwiftUI
+
+struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
+    static var shared: Self { QwertyShiftKeyModel() }
+
+    let keySizeType: QwertyKeySizeType = .normal(of: 1, for: 1)
+    var variationsModel = VariationsModel([])
+
+    let needSuggestView: Bool = false
+
+    func pressActions(variableStates: VariableStates) -> [ActionType] {
+        if variableStates.boolStates.isCapsLocked {
+            return [.setBoolState(VariableStates.BoolStates.isCapsLockedKey, .off)]
+        } else if variableStates.boolStates.isShifted {
+            return [.setBoolState(VariableStates.BoolStates.isShiftedKey, .off)]
+        } else {
+            return [.setBoolState(VariableStates.BoolStates.isShiftedKey, .on)]
+        }
+    }
+
+    var longPressActions: LongpressActionType {
+        .init(start: [.setBoolState(VariableStates.BoolStates.isCapsLockedKey, .toggle)])
+    }
+
+    func doublePressActions(variableStates: VariableStates) -> [ActionType] {
+        if variableStates.boolStates.isCapsLocked {
+            return []
+        } else {
+            return [.setBoolState(VariableStates.BoolStates.isCapsLockedKey, .on)]
+        }
+    }
+    
+    func label<Extension: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+        if states.boolStates.isCapsLocked {
+            return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
+        } else if states.boolStates.isShifted {
+            return KeyLabel(.image("shift.fill"), width: width, textColor: color)
+        } else {
+            return KeyLabel(.image("shift"), width: width, textColor: color)
+        }
+    }
+
+    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+
+    func feedback(variableStates: VariableStates) {
+        KeyboardFeedback<Extension>.tabOrOtherKey()
+    }
+
+}

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
@@ -526,18 +526,30 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             QwertyKeyModel<Extension>(labelType: .text("o"), pressActions: [.input("o")]),
             QwertyKeyModel<Extension>(labelType: .text("p"), pressActions: [.input("p")])
         ],
-        [
-            QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
-            QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
-            QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
-            QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
-            QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
-            QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
-            QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
-            QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
-            QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")]),
-            QwertyAaKeyModel<Extension>.shared
-        ],
+        Extension.SettingProvider.useShiftKey ?
+            [
+                QwertyShiftKeyModel<Extension>.shared,
+                QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
+                QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
+                QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
+                QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
+                QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
+                QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
+                QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
+                QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
+                QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")]),
+            ] : [
+                QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
+                QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
+                QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
+                QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
+                QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
+                QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
+                QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
+                QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
+                QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")]),
+                QwertyAaKeyModel<Extension>.shared,
+            ],
         [
             Self.tabKeys(rowInfo: (7, 2, 0, 0)).languageKey,
             QwertyKeyModel<Extension>(labelType: .text("z"), pressActions: [.input("z")]),


### PR DESCRIPTION
* #252 に基づいてシフトキーの実装を追加した（Resolve #251 ）
* #251 ではone-offのステートを追加することを検討したが、一旦は愚直な実装でもそこまで悪くないと判断した
* 現在は`ApplicationSpecificKeyboardViewSettingProvider`の中で`useShiftKey`というパラメータを追加して制御している。一旦常に`false`にした。
* azooKey本体のユーザ設定として露出させるかは別途判断する。