### PR TITLE
[Feature] `ThemeData`にShadowの設定を追加し、標準キーボード風の影を追加できるようにした

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
@@ -55,7 +55,8 @@ public extension AzooKeyTheme {
         normalKeyFillColor: .color(Color(.displayP3, white: 1, opacity: 1)),
         specialKeyFillColor: .color(Color(.displayP3, red: 0.804, green: 0.808, blue: 0.835)),
         pushedKeyFillColor: .color(Color(.displayP3, red: 0.929, green: 0.929, blue: 0.945)),
-        suggestKeyFillColor: nil
+        suggestKeyFillColor: nil,
+        keyShadow: nil
     )
 }
 
@@ -73,7 +74,8 @@ extension AzooKeySpecificTheme: ApplicationSpecificKeyboardViewExtensionLayoutDe
             normalKeyFillColor: .system(layout == .qwerty ? .qwertyNormalKeyColor : .normalKeyColor),
             specialKeyFillColor: .system(.specialKeyColor),
             pushedKeyFillColor: .system(layout == .qwerty ? .qwertyHighlightedKeyColor : .highlightedKeyColor),
-            suggestKeyFillColor: nil
+            suggestKeyFillColor: nil,
+            keyShadow: nil
         )
     }
 }

--- a/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
+++ b/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
@@ -24,8 +24,9 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
     public var specialKeyFillColor: ColorData
     public var pushedKeyFillColor: ColorData   // 自動で設定する
     public var suggestKeyFillColor: ColorData?  // 自動で設定する
+    public var keyShadow: ThemeShadowData<ColorData>?
 
-    public init(id: Int? = nil, backgroundColor: ColorData, picture: ThemePicture, textColor: ColorData, textFont: ThemeFontWeight, resultTextColor: ColorData, resultBackgroundColor: ColorData, borderColor: ColorData, borderWidth: Double, normalKeyFillColor: ColorData, specialKeyFillColor: ColorData, pushedKeyFillColor: ColorData, suggestKeyFillColor: ColorData? = nil) {
+    public init(id: Int? = nil, backgroundColor: ColorData, picture: ThemePicture, textColor: ColorData, textFont: ThemeFontWeight, resultTextColor: ColorData, resultBackgroundColor: ColorData, borderColor: ColorData, borderWidth: Double, normalKeyFillColor: ColorData, specialKeyFillColor: ColorData, pushedKeyFillColor: ColorData, suggestKeyFillColor: ColorData? = nil, keyShadow: ThemeShadowData<ColorData>? = nil) {
         self.id = id
         self.backgroundColor = backgroundColor
         self.picture = picture
@@ -39,6 +40,7 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         self.specialKeyFillColor = specialKeyFillColor
         self.pushedKeyFillColor = pushedKeyFillColor
         self.suggestKeyFillColor = suggestKeyFillColor
+        self.keyShadow = keyShadow
     }
 
     enum CodingKeys: CodingKey {
@@ -55,6 +57,7 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         case specialKeyFillColor
         case pushedKeyFillColor
         case suggestKeyFillColor
+        case keyShadow
     }
 
     public init(from decoder: any Decoder) throws {
@@ -73,8 +76,23 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         self.specialKeyFillColor = try container.decode(ColorData.self, forKey: .specialKeyFillColor)
         self.pushedKeyFillColor = try container.decode(ColorData.self, forKey: .pushedKeyFillColor)
         self.suggestKeyFillColor = try? container.decode(ColorData?.self, forKey: .suggestKeyFillColor)
+        self.keyShadow = try? container.decode(ThemeShadowData<ColorData>?.self, forKey: .keyShadow)
     }
 
+}
+
+public struct ThemeShadowData<ColorData>: Codable, Equatable, Sendable where ColorData: Codable & Equatable & Sendable {
+    public init(color: ColorData, radius: CGFloat, x: CGFloat, y: CGFloat) {
+        self.color = color
+        self.radius = radius
+        self.x = x
+        self.y = y
+    }
+    
+    public var color: ColorData
+    public var radius: CGFloat
+    public var x: CGFloat
+    public var y: CGFloat
 }
 
 public enum ThemeFontWeight: Int, Codable, Sendable {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -226,6 +226,8 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
             .strokeAndFill(fillContent: keyFillColor, strokeContent: keyBorderColor, lineWidth: theme.borderWidth)
             .frame(width: keySize.width, height: keySize.height)
             .gesture(gesture)
+            .compositingGroup()
+            .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
             .overlay(self.label(width: keySize.width))
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -235,6 +235,8 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             .size(CGSize(width: size.width + tabDesign.horizontalSpacing, height: size.height + tabDesign.verticalSpacing))
                     )
                     .gesture(gesture)
+                    .compositingGroup()
+                    .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
                     .overlay(label(width: size.width, color: nil))
             }
             .overlay(Group {


### PR DESCRIPTION
* #194 の処理
* azooKeyの着せ替えエディタに露出させるかは別途検討する