### PR TITLE
[Fix] \nが変換に現れる問題を修正

### DIFF
--- a/MainApp/LOUDSLogic/LOUDSBuilder.swift
+++ b/MainApp/LOUDSLogic/LOUDSBuilder.swift
@@ -150,7 +150,7 @@ struct LOUDSBuilder {
             let right = word[range.upperBound..<word.endIndex]
             return parseTemplate(left) + center + parseTemplate(right)
         } else {
-            return word.escaped()
+            return String(word)
         }
     }
 

--- a/azooKeyTests/KeyboardTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/azooKeyTests/KeyboardTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -68,7 +68,8 @@ final class DicdataStoreTests: XCTestCase {
             ("タイ", "体."),
             ("アサッテ", "明日"),
             ("チョ", "ちょwww"),
-            ("a", "あ")   // direct入力の場合「a」で「あ」をサジェストしてはいけない
+            ("a", "あ"),   // direct入力の場合「a」で「あ」をサジェストしてはいけない
+            ("\\n", "\n")
         ]
         for (key, word) in mustWords {
             var c = ComposingText()


### PR DESCRIPTION
Fix #261 
こちらのPRと合わせて修正。
https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter/pull/13