### PR TITLE
[Refactoring] Swift 5.9のenable upcoming feature flagを追加

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: macos-latest
 
     steps: 
-    - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+    - uses: swift-actions/setup-swift@150267bf6ba01f9d942a4bd55aa2f35ba586767d
       with:
-        swift-version: "5.8"
+        swift-version: "5.9"
     - uses: actions/checkout@v3
     - name: Build
       # TODO: add KeyboardViews

--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -11,6 +11,7 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ImplicitOpenExistentials"),
     .enableUpcomingFeature("StrictConcurrency"),
     .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("ImportObjcForwardDeclarations"),
     .unsafeFlags(["-strict-concurrency=complete"])
 ]
 let package = Package(

--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -10,6 +10,7 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("ImplicitOpenExistentials"),
     .enableUpcomingFeature("StrictConcurrency"),
+    .enableUpcomingFeature("DisableOutwardActorInference"),
     .unsafeFlags(["-strict-concurrency=complete"])
 ]
 let package = Package(

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ExpandedResultView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ExpandedResultView.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 
+@MainActor
 struct ExpandedResultView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @Binding private var isResultViewExpanded: Bool

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
@@ -18,6 +18,7 @@ public enum KeyLabelType {
     case selectable(String, String)
 }
 
+@MainActor
 public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let labelType: KeyLabelType
     private let width: CGFloat

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import SwiftUIUtils
 
+@MainActor
 struct LargeTextView: View {
     private let text: String
     @Binding private var isViewOpen: Bool

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/MessageView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/MessageView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@MainActor
 struct MessageView<ID: MessageIdentifierProtocol>: View {
     private let data: MessageData<ID>
     @Binding private var manager: MessageManager<ID>

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+@MainActor
 struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     typealias Position = (current: CGPoint, initial: CGPoint)
     @State private var top_left_edge: Position
@@ -279,6 +280,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     }
 }
 
+@MainActor
 struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>: ViewModifier {
     private let initialSize: CGSize
     @Binding private var position: CGPoint

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -253,6 +253,7 @@ extension CustardInterfaceKey {
     }
 }
 
+@MainActor
 struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let custard: Custard
     private var tabDesign: TabDependentDesign {

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import SwiftUIUtils
 
+@MainActor
 struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let model: any SimpleKeyModelProtocol
     @EnvironmentObject private var variableStates: VariableStates

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -26,6 +26,7 @@ enum KeyPressState {
     }
 }
 
+@MainActor
 public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let model: any FlickKeyModelProtocol
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/SuggestView/FlickSuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/SuggestView/FlickSuggestView.swift
@@ -10,6 +10,7 @@ import CustardKit
 import Foundation
 import SwiftUI
 
+@MainActor
 struct FlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @Environment(Extension.Theme.self) private var theme

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import SwiftUIUtils
 
+@MainActor
 struct EmojiTabResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     init() {}
     @Environment(Extension.Theme.self) private var theme

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import SwiftUIUtils
 
+@MainActor
 struct KeyboardBarView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @Binding private var isResultViewExpanded: Bool
@@ -37,6 +38,7 @@ struct KeyboardBarView<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
     }
 }
 
+@MainActor
 struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     enum LabelType {
         case azooKeyIcon

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/MoveCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/MoveCursorBar.swift
@@ -68,6 +68,7 @@ struct BetaMoveCursorBarState {
     }
 }
 
+@MainActor
 struct MoveCursorBarBeta<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     init() {}
 
@@ -283,6 +284,7 @@ private enum MoveCursorBarGestureState {
     case moving(CGPoint, Int)   // 右だったら+1、左だったら-1
 }
 
+@MainActor
 struct MoveCursorBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     init() {}
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
@@ -21,6 +21,7 @@ private extension Equatable {
     }
 }
 
+@MainActor
 struct ResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @Namespace private var namespace
     @Environment(Extension.Theme.self) private var theme

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 
+@MainActor
 public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @State private var messageManager = MessageManager(necessaryMessages: Extension.MessageProvider.messages, userDefaults: Extension.MessageProvider.userDefaults)
     @State private var isResultViewExpanded = false

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -96,6 +96,7 @@ struct QwertyKeyDoublePressState {
     }
 }
 
+@MainActor
 struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let model: any QwertyKeyModelProtocol
     @EnvironmentObject private var variableStates: VariableStates

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
@@ -47,6 +47,7 @@ private final class ClipboardHistory: ObservableObject {
     }
 }
 
+@MainActor
 struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @StateObject private var target = ClipboardHistory()

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -10,6 +10,7 @@ import KeyboardThemes
 import SwiftUI
 import SwiftUtils
 
+@MainActor
 struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @EnvironmentObject private var variableStates: VariableStates
     @Environment(Extension.Theme.self) private var theme

--- a/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import enum KanaKanjiConverterModule.ConverterBehaviorSemantics
 
+@MainActor
 struct UpsideSearchView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     @Environment(\.userActionManager) private var action
     @Environment(Extension.Theme.self) private var theme

--- a/MainApp/ContentView.swift
+++ b/MainApp/ContentView.swift
@@ -10,6 +10,7 @@ import AzooKeyUtils
 import KeyboardViews
 import SwiftUI
 
+@MainActor
 struct ContentView: View {
     private enum TabSelection {
         case tips, theme, customize, settings

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -29,6 +29,7 @@ fileprivate extension Dictionary where Key == KeyPosition, Value == UserMadeTenK
     }
 }
 
+@MainActor
 struct EditingTenkeyCustardView: CancelableEditor {
     private static let emptyKey: UserMadeTenKeyCustard.KeyData = .init(model: .custom(.empty), width: 1, height: 1)
     private static let emptyKeys: [KeyPosition: UserMadeTenKeyCustard.KeyData] = (0..<5).reduce(into: [:]) {dict, x in

--- a/MainApp/Customize/ManageCustardView.swift
+++ b/MainApp/Customize/ManageCustardView.swift
@@ -142,6 +142,7 @@ struct WebCustardList: Codable {
     var custards: [Item]
 }
 
+@MainActor
 struct ManageCustardView: View {
     @ObservedObject private var data = ImportedCustardData()
     @State private var urlString: String = ""
@@ -369,6 +370,7 @@ struct ManageCustardView: View {
 }
 
 // FIXME: ファイルを保存もキャンセルもしない状態で2つ目のファイルを読み込むとエラーになる
+@MainActor
 struct URLImportCustardView: View {
     @ObservedObject private var data = ImportedCustardData()
     @State private var showAlert = false

--- a/MainApp/EnableAzooKeyView/EnableAzooKeyView.swift
+++ b/MainApp/EnableAzooKeyView/EnableAzooKeyView.swift
@@ -18,6 +18,7 @@ private enum EnableAzooKeyViewStep {
     case setting
 }
 
+@MainActor
 struct EnableAzooKeyView: View {
     @EnvironmentObject private var appStates: MainAppStates
     @State private var step: EnableAzooKeyViewStep = .menu

--- a/MainApp/General/KeyboardPreview.swift
+++ b/MainApp/General/KeyboardPreview.swift
@@ -21,6 +21,7 @@ private struct CandidateMock: ResultViewItemData {
     #endif
 }
 
+@MainActor
 struct KeyboardPreview: View {
     private let theme: AzooKeyTheme
 

--- a/MainApp/Setting/AdditionalDict/AdditionalDictManageView.swift
+++ b/MainApp/Setting/AdditionalDict/AdditionalDictManageView.swift
@@ -126,6 +126,7 @@ final class AdditionalDictManager: ObservableObject {
 
 }
 
+@MainActor
 struct AdditionalDictManageViewMain: View {
     enum Style {
         case simple

--- a/MainApp/Setting/AdditionalDict/AzooKeyUserDictionary.swift
+++ b/MainApp/Setting/AdditionalDict/AzooKeyUserDictionary.swift
@@ -63,6 +63,7 @@ struct AzooKeyUserDictionaryView: View {
     }
 }
 
+@MainActor
 private struct UserDictionaryDataListView: View {
     private let exceptionKey = "その他"
 
@@ -142,6 +143,7 @@ private struct UserDictionaryDataListView: View {
     }
 }
 
+@MainActor
 private struct UserDictionaryDataEditor: CancelableEditor {
     @ObservedObject private var item: EditableUserDictionaryData
     @ObservedObject private var variables: UserDictManagerVariables

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -101,6 +101,7 @@ private struct Selection: Hashable {
     var longpressEnabled = false
 }
 
+@MainActor
 struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: View {
     @StateObject private var editState = EditState()
     @State private var setting = SettingUpdater<SettingKey>()

--- a/MainApp/Setting/FontSizeSetting/FontSizeSettingItemView.swift
+++ b/MainApp/Setting/FontSizeSetting/FontSizeSettingItemView.swift
@@ -73,6 +73,7 @@ struct FontSizeSettingView<SettingKey: DoubleKeyboardSettingKey>: View {
     }
 }
 
+@MainActor
 private struct KeyView: View {
     @EnvironmentObject private var appStates: MainAppStates
     private let fontSize: CGFloat

--- a/MainApp/Setting/KeyboardLayout/KeyboardLayoutSettingItemView.swift
+++ b/MainApp/Setting/KeyboardLayout/KeyboardLayoutSettingItemView.swift
@@ -25,6 +25,7 @@ extension LanguageLayout {
     }
 }
 
+@MainActor
 struct LanguageLayoutSettingView<SettingKey: LanguageLayoutKeyboardSetting>: View {
     @EnvironmentObject private var appStates: MainAppStates
     @State private var selection: LanguageLayout = .flick

--- a/MainApp/Setting/Template/TemplateListView.swift
+++ b/MainApp/Setting/Template/TemplateListView.swift
@@ -26,6 +26,7 @@ private final class NavigationModel: ObservableObject {
 }
 
 // Listが大元のtemplatesを持ち、各EditingViewにBindingで渡して編集させる。
+@MainActor
 struct TemplateListView: View {
     private static let dataFileName = "user_templates.json"
     @ObservedObject private var data = TemplateDataList()

--- a/MainApp/Theme/ThemeTab.swift
+++ b/MainApp/Theme/ThemeTab.swift
@@ -12,6 +12,7 @@ import SwiftUI
 import SwiftUIUtils
 import SwiftUtils
 
+@MainActor
 struct ThemeTabView: View {
     @Namespace private var namespace
     @EnvironmentObject private var appStates: MainAppStates

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -1634,7 +1634,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.2;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature DisableOutwardActorInference";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature ImportObjcForwardDeclarations";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1802,7 +1802,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.2;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature DisableOutwardActorInference";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature ImportObjcForwardDeclarations -enable-upcoming-feature DisableOutwardActorInference";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -1634,7 +1634,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.2;
-				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials";
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature DisableOutwardActorInference";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1802,7 +1802,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.2;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=300 -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ImplicitOpenExistentials -enable-upcoming-feature DisableOutwardActorInference";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
#281 の一環
* `DisableOutwardActorInference`を追加→かなり差分が発生
* `ImportObjcForwardDeclarations`を追加→差分なし