### PR TITLE
[Fix] 依存パッケージのバージョンを固定し、決め方について追記

### DIFF
--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -38,8 +38,11 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter", branch: "develop")
+        // MARK: You must specify version which results reproductive and stable result
+        // MARK: `_: .upToNextMinor(Version)` or `exact: Version` or `revision: Version`.
+        // MARK: For develop branch, you can use `revision:` specification.
+        // MARK: For main branch, you must use `upToNextMinor` specification.
+        .package(url: "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter", .upToNextMinor(from: "0.4.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -1933,8 +1933,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ensan-hcl/BoolExpressionEvaluator";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = exactVersion;
+				version = 0.0.1;
 			};
 		};
 		1A70DFFB291F2D1E00A83849 /* XCRemoteSwiftPackageReference "CustardKit" */ = {


### PR DESCRIPTION
Fix #309 

`develop`ブランチではcommit id直接指定を許可し、`main`では`upToMinor`の利用のみとする。