### PR TITLE
[Feature] QwertyKeyViewのサジェストに薄いシャドウを追加

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -214,6 +214,10 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
         theme != Extension.ThemeExtension.default(layout: .qwerty) ? .black : nil
     }
 
+    private var shadowColor: Color {
+        suggestTextColor?.opacity(0.5) ?? .black.opacity(0.5)
+    }
+
     private var selection: Int? {
         if case let .variations(selection) = pressState {
             return selection
@@ -259,6 +263,8 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                                 .padding(.bottom, height),
                             alignment: self.model.variationsModel.direction.alignment
                         )
+                        .compositingGroup()
+                        .shadow(color: shadowColor, radius: 1, x: 0, y: 0)
                         .allowsHitTesting(false)
                     } else {
                         QwertySuggestView.scaleToFrameSize(
@@ -273,6 +279,8 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             label(width: size.width, color: suggestTextColor)
                                 .padding(.bottom, height)
                         )
+                        .compositingGroup()
+                        .shadow(color: shadowColor, radius: 1, x: 0, y: 0)
                         .allowsHitTesting(false)
                     }
                 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
@@ -40,6 +40,6 @@ struct QwertyVariationsView<Extension: ApplicationSpecificKeyboardViewExtension>
     }
 
     @MainActor private func getLabel(_ labelType: KeyLabelType) -> KeyLabel<Extension> {
-        KeyLabel(labelType, width: tabDesign.keyViewWidth, textColor: theme.suggestLabelTextColor?.color)
+        KeyLabel(labelType, width: tabDesign.keyViewWidth, textColor: theme.suggestLabelTextColor?.color ?? .black)
     }
 }


### PR DESCRIPTION
薄めのシャドウを加え、他と区別しやすくした。
![image](https://github.com/ensan-hcl/azooKey/assets/63481257/7fbb3203-e483-4306-a67e-bb7d4e8fcafa)
