### PR TITLE
[Refactoring] `any P<T>`がiOS 16で利用可能になるので、導入する

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -131,23 +131,23 @@ extension CustardInterfaceKey {
         case let .system(value):
             switch value {
             case .changeKeyboard:
-                return FlickChangeKeyboardModel<Extension>.shared
+                return FlickChangeKeyboardModel.shared
             case .enter:
-                return FlickEnterKeyModel<Extension>()
+                return FlickEnterKeyModel()
             case .upperLower:
-                return FlickAaKeyModel<Extension>()
+                return FlickAaKeyModel()
             case .nextCandidate:
-                return FlickNextCandidateKeyModel<Extension>.shared
+                return FlickNextCandidateKeyModel.shared
             case .flickKogaki:
-                return FlickKogakiKeyModel<Extension>.shared
+                return FlickKogakiKeyModel.shared
             case .flickKutoten:
-                return FlickKanaSymbolsKeyModel<Extension>.shared
+                return FlickKanaSymbolsKeyModel.shared
             case .flickHiraTab:
-                return FlickTabKeyModel<Extension>.hiraTabKeyModel()
+                return FlickTabKeyModel.hiraTabKeyModel()
             case .flickAbcTab:
-                return FlickTabKeyModel<Extension>.abcTabKeyModel()
+                return FlickTabKeyModel.abcTabKeyModel()
             case .flickStar123Tab:
-                return FlickTabKeyModel<Extension>.numberTabKeyModel()
+                return FlickTabKeyModel.numberTabKeyModel()
             }
         case let .custom(value):
             let flickKeyModels: [FlickDirection: FlickedKeyModel] = value.variations.reduce(into: [:]) {dictionary, variation in
@@ -162,7 +162,7 @@ extension CustardInterfaceKey {
                     break
                 }
             }
-            let model = FlickKeyModel<Extension>(
+            return FlickKeyModel(
                 labelType: value.design.label.keyLabelType,
                 pressActions: value.press_actions.map {$0.actionType},
                 longPressActions: value.longpress_actions.longpressActionType,
@@ -170,7 +170,6 @@ extension CustardInterfaceKey {
                 needSuggestView: value.longpress_actions == .none && !value.variations.isEmpty,
                 keycolorType: value.design.color.flickKeyColorType
             )
-            return model
         }
     }
 
@@ -218,7 +217,7 @@ extension CustardInterfaceKey {
                 }
             }
 
-            let model = QwertyKeyModel<Extension>(
+            return QwertyKeyModel(
                 labelType: value.design.label.keyLabelType,
                 pressActions: value.press_actions.map {$0.actionType},
                 longPressActions: value.longpress_actions.longpressActionType,
@@ -227,7 +226,6 @@ extension CustardInterfaceKey {
                 needSuggestView: value.longpress_actions == .none,
                 for: (1, 1)
             )
-            return model
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -231,31 +231,31 @@ extension CustardInterfaceKey {
         }
     }
 
-    func simpleKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> any SimpleKeyModelProtocol {
+    func simpleKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> any SimpleKeyModelProtocol<Extension> {
         switch self {
         case let .system(value):
             switch value {
             case .changeKeyboard:
-                return SimpleChangeKeyboardKeyModel<Extension>()
+                return SimpleChangeKeyboardKeyModel()
             case .enter:
-                return SimpleEnterKeyModel<Extension>()
+                return SimpleEnterKeyModel()
             case .upperLower:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("a/A"), unpressedKeyColorType: .special, pressActions: [.changeCharacterType])
+                return SimpleKeyModel(keyLabelType: .text("a/A"), unpressedKeyColorType: .special, pressActions: [.changeCharacterType])
             case .nextCandidate:
-                return SimpleNextCandidateKeyModel<Extension>()
+                return SimpleNextCandidateKeyModel()
             case .flickKogaki:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("小ﾞﾟ"), unpressedKeyColorType: .special, pressActions: [.changeCharacterType])
+                return SimpleKeyModel(keyLabelType: .text("小ﾞﾟ"), unpressedKeyColorType: .special, pressActions: [.changeCharacterType])
             case .flickKutoten:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("、"), unpressedKeyColorType: .normal, pressActions: [.input("、")])
+                return SimpleKeyModel(keyLabelType: .text("、"), unpressedKeyColorType: .normal, pressActions: [.input("、")])
             case .flickHiraTab:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("あいう"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_japanese))])
+                return SimpleKeyModel(keyLabelType: .text("あいう"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_japanese))])
             case .flickAbcTab:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("abc"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_english))])
+                return SimpleKeyModel(keyLabelType: .text("abc"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_english))])
             case .flickStar123Tab:
-                return SimpleKeyModel<Extension>(keyLabelType: .text("☆123"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.flick_numbersymbols))])
+                return SimpleKeyModel(keyLabelType: .text("☆123"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.flick_numbersymbols))])
             }
         case let .custom(value):
-            return SimpleKeyModel<Extension>(
+            return SimpleKeyModel(
                 keyLabelType: value.design.label.keyLabelType,
                 unpressedKeyColorType: value.design.color.simpleKeyColorType,
                 pressActions: value.press_actions.map {$0.actionType},

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -71,7 +71,7 @@ fileprivate extension CustardInterface {
         }
     }
 
-    @MainActor func qwertyKeyModels<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> [KeyPosition: (model: any QwertyKeyModelProtocol, sizeType: QwertyKeySizeType)] {
+    @MainActor func qwertyKeyModels<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> [KeyPosition: (model: any QwertyKeyModelProtocol<Extension>, sizeType: QwertyKeySizeType)] {
         self.keys.reduce(into: [:]) {dictionary, value in
             switch value.key {
             case let .gridFit(data):
@@ -174,12 +174,12 @@ extension CustardInterfaceKey {
         }
     }
 
-    private func convertToQwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(customKey: KeyFlickSetting.SettingData, extension _: Extension.Type) -> any QwertyKeyModelProtocol {
+    private func convertToQwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(customKey: KeyFlickSetting.SettingData, extension _: Extension.Type) -> any QwertyKeyModelProtocol<Extension> {
         let variations = VariationsModel([customKey.flick[.left], customKey.flick[.top], customKey.flick[.right], customKey.flick[.bottom]].compactMap {$0}.map {(label: $0.labelType, actions: $0.pressActions)})
-        return QwertyKeyModel<Extension>(labelType: customKey.labelType, pressActions: customKey.actions, longPressActions: customKey.longpressActions, variationsModel: variations, keyColorType: .normal, needSuggestView: false, for: (1, 1))
+        return QwertyKeyModel(labelType: customKey.labelType, pressActions: customKey.actions, longPressActions: customKey.longpressActions, variationsModel: variations, keyColorType: .normal, needSuggestView: false, for: (1, 1))
     }
 
-    @MainActor func qwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(layout: CustardInterfaceLayout, extension: Extension.Type) -> any QwertyKeyModelProtocol {
+    @MainActor func qwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(layout: CustardInterfaceLayout, extension: Extension.Type) -> any QwertyKeyModelProtocol<Extension> {
         switch self {
         case let .system(value):
             switch value {
@@ -192,11 +192,11 @@ extension CustardInterfaceKey {
                 }
                 return changeKeyboardKey
             case .enter:
-                return QwertyEnterKeyModel<Extension>(keySizeType: .enter)
+                return QwertyEnterKeyModel(keySizeType: .enter)
             case .upperLower:
-                return QwertyAaKeyModel<Extension>()
+                return QwertyAaKeyModel()
             case .nextCandidate:
-                return QwertyNextCandidateKeyModel<Extension>()
+                return QwertyNextCandidateKeyModel()
             case .flickKogaki:
                 return convertToQwertyKeyModel(customKey: Extension.SettingProvider.koganaFlickCustomKey.compiled(), extension: Extension.self)
             case .flickKutoten:

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -60,7 +60,7 @@ fileprivate extension CustardInterface {
         }
     }
 
-    @MainActor func flickKeyModels<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] {
+    @MainActor func flickKeyModels<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)] {
         self.keys.reduce(into: [:]) {dictionary, value in
             switch value.key {
             case let .gridFit(data):
@@ -126,7 +126,7 @@ fileprivate extension CustardKeyDesign.ColorType {
 }
 
 extension CustardInterfaceKey {
-    @MainActor public func flickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> any FlickKeyModelProtocol {
+    @MainActor public func flickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> any FlickKeyModelProtocol<Extension> {
         switch self {
         case let .system(value):
             switch value {
@@ -337,7 +337,7 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
 public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExtension, Content: View>: View {
     @State private var suggestState = FlickSuggestState()
 
-    public init(models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)], tabDesign: TabDependentDesign, layout: CustardInterfaceLayoutGridValue, @ViewBuilder generator: @escaping (FlickKeyView<Extension>, Int, Int) -> (Content)) {
+    public init(models: [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)], tabDesign: TabDependentDesign, layout: CustardInterfaceLayoutGridValue, @ViewBuilder generator: @escaping (FlickKeyView<Extension>, Int, Int) -> (Content)) {
         self.models = models
         self.tabDesign = tabDesign
         self.layout = layout
@@ -345,7 +345,7 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
     }
 
     private let contentGenerator: (FlickKeyView<Extension>, Int, Int) -> (Content)
-    private let models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)]
+    private let models: [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)]
     private let tabDesign: TabDependentDesign
     private let layout: CustardInterfaceLayoutGridValue
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyModel.swift
@@ -47,14 +47,14 @@ enum SimpleUnpressedKeyColorType: UInt8 {
     }
 }
 
-protocol SimpleKeyModelProtocol {
+protocol SimpleKeyModelProtocol<Extension> {
     associatedtype Extension: ApplicationSpecificKeyboardViewExtension
 
     var unpressedKeyColorType: SimpleUnpressedKeyColorType {get}
     @MainActor func pressActions(variableStates: VariableStates) -> [ActionType]
     @MainActor func longPressActions(variableStates: VariableStates) -> LongpressActionType
     @MainActor func feedback(variableStates: VariableStates)
-    @MainActor func label<Extension: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: Extension.Theme) -> KeyLabel<Extension>
+    @MainActor func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension>
     @MainActor func backGroundColorWhenPressed(theme: Extension.Theme) -> Color
     /// `pressActions`とは別に、押された際に発火する操作
     /// - note: タブ固有の事情で実行しなければならないような処理に利用すること
@@ -82,7 +82,7 @@ struct SimpleKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Simp
     private let pressActions: [ActionType]
     let longPressActions: LongpressActionType
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.keyLabelType, width: width)
     }
 
@@ -115,7 +115,7 @@ struct SimpleEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
     }
 
     let unpressedKeyColorType: SimpleUnpressedKeyColorType = .enter
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         let text = Design.language.getEnterKeyText(states.enterKeyState)
         return KeyLabel(.text(text), width: width)
     }
@@ -148,7 +148,7 @@ struct SimpleNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
         }
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         if states.resultModel.results.isEmpty {
             KeyLabel(.text("空白"), width: width)
         } else {
@@ -182,7 +182,7 @@ struct SimpleChangeKeyboardKeyModel<Extension: ApplicationSpecificKeyboardViewEx
         .none
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         if SemiStaticStates.shared.needsInputModeSwitchKey {
             return KeyLabel(.changeKeyboard, width: width)
         } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -12,7 +12,7 @@ import SwiftUIUtils
 
 @MainActor
 struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
-    private let model: any SimpleKeyModelProtocol
+    private let model: any SimpleKeyModelProtocol<Extension>
     @EnvironmentObject private var variableStates: VariableStates
     @Environment(Extension.Theme.self) private var theme
     @Environment(\.userActionManager) private var action
@@ -20,13 +20,13 @@ struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     private let keyViewWidth: CGFloat
     private let keyViewHeight: CGFloat
 
-    init(model: any SimpleKeyModelProtocol, tabDesign: TabDependentDesign) {
+    init(model: any SimpleKeyModelProtocol<Extension>, tabDesign: TabDependentDesign) {
         self.model = model
         self.keyViewWidth = tabDesign.keyViewWidth
         self.keyViewHeight = tabDesign.keyViewHeight
     }
 
-    init(model: any SimpleKeyModelProtocol, width: CGFloat, height: CGFloat) {
+    init(model: any SimpleKeyModelProtocol<Extension>, width: CGFloat, height: CGFloat) {
         self.model = model
         self.keyViewWidth = width
         self.keyViewHeight = height
@@ -36,7 +36,7 @@ struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     @State private var pressStartDate = Date()
 
     private func label(width: CGFloat) -> some View {
-        model.label(width: keyViewWidth, states: variableStates, theme: theme) as KeyLabel<Extension>
+        model.label(width: keyViewWidth, states: variableStates)
     }
 
     var body: some View {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickDataProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickDataProvider.swift
@@ -15,59 +15,59 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
         Extension.SettingProvider.preferredLanguage
     }
 
-    @MainActor static func TabKeys() -> [any FlickKeyModelProtocol] {
-        let first: any FlickKeyModelProtocol = {
+    @MainActor static func TabKeys() -> [any FlickKeyModelProtocol<Extension>] {
+        let first: any FlickKeyModelProtocol<Extension> = {
             switch preferredLanguage.first {
-            case .el_GR: return FlickChangeKeyboardModel<Extension>.shared
-            case .en_US: return FlickTabKeyModel<Extension>.abcTabKeyModel()
-            case .ja_JP: return FlickTabKeyModel<Extension>.hiraTabKeyModel()
-            case .none: return FlickChangeKeyboardModel<Extension>.shared
+            case .el_GR: return FlickChangeKeyboardModel.shared
+            case .en_US: return FlickTabKeyModel.abcTabKeyModel()
+            case .ja_JP: return FlickTabKeyModel.hiraTabKeyModel()
+            case .none: return FlickChangeKeyboardModel.shared
             }
         }()
 
-        let second: (any FlickKeyModelProtocol)? = {
+        let second: (any FlickKeyModelProtocol<Extension>)? = {
             guard let second = preferredLanguage.second else {
                 return nil
             }
             switch second {
             case .none: return nil
-            case .el_GR: return FlickChangeKeyboardModel<Extension>.shared
-            case .en_US: return FlickTabKeyModel<Extension>.abcTabKeyModel()
-            case .ja_JP: return FlickTabKeyModel<Extension>.hiraTabKeyModel()
+            case .el_GR: return FlickChangeKeyboardModel.shared
+            case .en_US: return FlickTabKeyModel.abcTabKeyModel()
+            case .ja_JP: return FlickTabKeyModel.hiraTabKeyModel()
             }
         }()
 
         if let second {
             return [
-                FlickTabKeyModel<Extension>.numberTabKeyModel(),
+                FlickTabKeyModel.numberTabKeyModel(),
                 second,
                 first,
-                FlickChangeKeyboardModel<Extension>.shared
+                FlickChangeKeyboardModel.shared
             ]
         } else {
             return [
-                FlickKeyModel<Extension>(
+                FlickKeyModel(
                     labelType: .image("list.bullet"),
                     pressActions: [.setTabBar(.toggle)], longPressActions: .init(start: [.setTabBar(.toggle)]),
                     flickKeys: [:],
                     needSuggestView: false,
                     keycolorType: .tabkey
                 ),
-                FlickTabKeyModel<Extension>.numberTabKeyModel(),
+                FlickTabKeyModel.numberTabKeyModel(),
                 first,
-                FlickChangeKeyboardModel<Extension>.shared
+                FlickChangeKeyboardModel.shared
             ]
         }
     }
     // 縦に並べる
     @MainActor
-    static var hiraKeyboard: [[any FlickKeyModelProtocol]] {
+    static var hiraKeyboard: [[any FlickKeyModelProtocol<Extension>]] {
         [
             // 第1列
             Self.TabKeys(),
             // 第2列
             [
-                FlickKeyModel<Extension>(labelType: .text("あ"), pressActions: [.input("あ")], flickKeys: [
+                FlickKeyModel(labelType: .text("あ"), pressActions: [.input("あ")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("い"),
                         pressActions: [.input("い")]
@@ -86,7 +86,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("た"), pressActions: [.input("た")], flickKeys: [
+                FlickKeyModel(labelType: .text("た"), pressActions: [.input("た")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("ち"),
                         pressActions: [.input("ち")]
@@ -104,7 +104,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("と")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("ま"), pressActions: [.input("ま")], flickKeys: [
+                FlickKeyModel(labelType: .text("ま"), pressActions: [.input("ま")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("み"),
                         pressActions: [.input("み")]
@@ -123,11 +123,11 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKogakiKeyModel<Extension>.shared
+                FlickKogakiKeyModel.shared
             ],
             // 第3列
             [
-                FlickKeyModel<Extension>(labelType: .text("か"), pressActions: [.input("か")], flickKeys: [
+                FlickKeyModel(labelType: .text("か"), pressActions: [.input("か")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("き"),
                         pressActions: [.input("き")]
@@ -146,7 +146,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("な"), pressActions: [.input("な")], flickKeys: [
+                FlickKeyModel(labelType: .text("な"), pressActions: [.input("な")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("に"),
                         pressActions: [.input("に")]
@@ -165,7 +165,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("や"), pressActions: [.input("や")], flickKeys: [
+                FlickKeyModel(labelType: .text("や"), pressActions: [.input("や")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("「"),
                         pressActions: [.input("「")]
@@ -184,7 +184,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("わ"), pressActions: [.input("わ")], flickKeys: [
+                FlickKeyModel(labelType: .text("わ"), pressActions: [.input("わ")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("を"),
                         pressActions: [.input("を")]
@@ -202,7 +202,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第4列
             [
-                FlickKeyModel<Extension>(labelType: .text("さ"), pressActions: [.input("さ")], flickKeys: [
+                FlickKeyModel(labelType: .text("さ"), pressActions: [.input("さ")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("し"),
                         pressActions: [.input("し")]
@@ -221,7 +221,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("は"), pressActions: [.input("は")], flickKeys: [
+                FlickKeyModel(labelType: .text("は"), pressActions: [.input("は")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("ひ"),
                         pressActions: [.input("ひ")]
@@ -240,7 +240,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("ら"), pressActions: [.input("ら")], flickKeys: [
+                FlickKeyModel(labelType: .text("ら"), pressActions: [.input("ら")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("り"),
                         pressActions: [.input("り")]
@@ -259,13 +259,13 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
 
                 ]),
-                FlickKanaSymbolsKeyModel<Extension>.shared
+                FlickKanaSymbolsKeyModel.shared
             ],
             // 第5列
             [
-                FlickKeyModel<Extension>.delete,
-                FlickSpaceKeyModel<Extension>.shared,
-                FlickEnterKeyModel<Extension>.shared
+                FlickKeyModel.delete,
+                FlickSpaceKeyModel.shared,
+                FlickEnterKeyModel.shared
             ]
 
         ]
@@ -273,13 +273,13 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
 
     // 縦に並べる
     @MainActor
-    static var abcKeyboard: [[any FlickKeyModelProtocol]] {
+    static var abcKeyboard: [[any FlickKeyModelProtocol<Extension>]] {
         [
             // 第1列
             Self.TabKeys(),
             // 第2列
             [
-                FlickKeyModel<Extension>(labelType: .text("@#/&_"), pressActions: [.input("@")], flickKeys: [
+                FlickKeyModel(labelType: .text("@#/&_"), pressActions: [.input("@")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("#"),
                         pressActions: [.input("#")]
@@ -297,7 +297,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("_")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("GHI"), pressActions: [.input("g")], flickKeys: [
+                FlickKeyModel(labelType: .text("GHI"), pressActions: [.input("g")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("H"),
                         pressActions: [.input("h")]
@@ -307,7 +307,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("i")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("PQRS"), pressActions: [.input("p")], flickKeys: [
+                FlickKeyModel(labelType: .text("PQRS"), pressActions: [.input("p")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("Q"),
                         pressActions: [.input("q")]
@@ -321,12 +321,12 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("s")]
                     )
                 ]),
-                FlickAaKeyModel<Extension>.shared
+                FlickAaKeyModel.shared
 
             ],
             // 第3列
             [
-                FlickKeyModel<Extension>(labelType: .text("ABC"), pressActions: [.input("a")], flickKeys: [
+                FlickKeyModel(labelType: .text("ABC"), pressActions: [.input("a")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("B"),
                         pressActions: [.input("b")]
@@ -336,7 +336,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("c")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("JKL"), pressActions: [.input("j")], flickKeys: [
+                FlickKeyModel(labelType: .text("JKL"), pressActions: [.input("j")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("K"),
                         pressActions: [.input("k")]
@@ -346,7 +346,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("l")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("TUV"), pressActions: [.input("t")], flickKeys: [
+                FlickKeyModel(labelType: .text("TUV"), pressActions: [.input("t")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("U"),
                         pressActions: [.input("u")]
@@ -356,7 +356,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("v")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("\'\"()"), pressActions: [.input("\'")], flickKeys: [
+                FlickKeyModel(labelType: .text("\'\"()"), pressActions: [.input("\'")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("\""),
                         pressActions: [.input("\"")]
@@ -374,7 +374,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第4列
             [
-                FlickKeyModel<Extension>(labelType: .text("DEF"), pressActions: [.input("d")], flickKeys: [
+                FlickKeyModel(labelType: .text("DEF"), pressActions: [.input("d")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("E"),
                         pressActions: [.input("e")]
@@ -385,7 +385,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
                 ]),
 
-                FlickKeyModel<Extension>(labelType: .text("MNO"), pressActions: [.input("m")], flickKeys: [
+                FlickKeyModel(labelType: .text("MNO"), pressActions: [.input("m")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("N"),
                         pressActions: [.input("n")]
@@ -396,7 +396,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
                 ]),
 
-                FlickKeyModel<Extension>(labelType: .text("WXYZ"), pressActions: [.input("w")], flickKeys: [
+                FlickKeyModel(labelType: .text("WXYZ"), pressActions: [.input("w")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("X"),
                         pressActions: [.input("x")]
@@ -410,7 +410,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("z")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text(".,?!"), pressActions: [.input(".")], flickKeys: [
+                FlickKeyModel(labelType: .text(".,?!"), pressActions: [.input(".")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text(","),
                         pressActions: [.input(",")]
@@ -427,21 +427,21 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第5列
             [
-                FlickKeyModel<Extension>.delete,
-                FlickSpaceKeyModel<Extension>.shared,
-                FlickEnterKeyModel<Extension>.shared
+                FlickKeyModel.delete,
+                FlickSpaceKeyModel.shared,
+                FlickEnterKeyModel.shared
             ]
         ]
     }
     // 縦に並べる
     @MainActor
-    static var numberKeyboard: [[any FlickKeyModelProtocol]] {
+    static var numberKeyboard: [[any FlickKeyModelProtocol<Extension>]] {
         [
             // 第1列
             Self.TabKeys(),
             // 第2列
             [
-                FlickKeyModel<Extension>(labelType: .symbols(["1", "☆", "♪", "→"]), pressActions: [.input("1")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["1", "☆", "♪", "→"]), pressActions: [.input("1")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("☆"),
                         pressActions: [.input("☆")]
@@ -455,7 +455,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("→")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .symbols(["4", "○", "＊", "・"]), pressActions: [.input("4")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["4", "○", "＊", "・"]), pressActions: [.input("4")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("○"),
                         pressActions: [.input("○")]
@@ -469,7 +469,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("・")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .symbols(["7", "「", "」", ":"]), pressActions: [.input("7")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["7", "「", "」", ":"]), pressActions: [.input("7")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("「"),
                         pressActions: [.input("「")]
@@ -483,7 +483,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input(":")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text("()[]"), pressActions: [.input("(")], flickKeys: [
+                FlickKeyModel(labelType: .text("()[]"), pressActions: [.input("(")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text(")"),
                         pressActions: [.input(")")]
@@ -501,7 +501,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第3列
             [
-                FlickKeyModel<Extension>(labelType: .symbols(["2", "¥", "$", "€"]), pressActions: [.input("2")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["2", "¥", "$", "€"]), pressActions: [.input("2")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("¥"),
                         pressActions: [.input("¥")]
@@ -515,7 +515,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("€")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .symbols(["5", "+", "×", "÷"]), pressActions: [.input("5")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["5", "+", "×", "÷"]), pressActions: [.input("5")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("+"),
                         pressActions: [.input("+")]
@@ -529,7 +529,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("÷")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .symbols(["8", "〒", "々", "〆"]), pressActions: [.input("8")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["8", "〒", "々", "〆"]), pressActions: [.input("8")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("〒"),
                         pressActions: [.input("〒")]
@@ -543,7 +543,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("〆")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .symbols(["0", "〜", "…"]), pressActions: [.input("0")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["0", "〜", "…"]), pressActions: [.input("0")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("〜"),
                         pressActions: [.input("〜")]
@@ -557,7 +557,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第4列
             [
-                FlickKeyModel<Extension>(labelType: .symbols(["3", "%", "°", "#"]), pressActions: [.input("3")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["3", "%", "°", "#"]), pressActions: [.input("3")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("%"),
                         pressActions: [.input("%")]
@@ -572,7 +572,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
                 ]),
 
-                FlickKeyModel<Extension>(labelType: .symbols(["6", "<", "=", ">"]), pressActions: [.input("6")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["6", "<", "=", ">"]), pressActions: [.input("6")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("<"),
                         pressActions: [.input("<")]
@@ -587,7 +587,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     )
                 ]),
 
-                FlickKeyModel<Extension>(labelType: .symbols(["9", "^", "|", "\\"]), pressActions: [.input("9")], flickKeys: [
+                FlickKeyModel(labelType: .symbols(["9", "^", "|", "\\"]), pressActions: [.input("9")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text("^"),
                         pressActions: [.input("^")]
@@ -601,7 +601,7 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                         pressActions: [.input("\\")]
                     )
                 ]),
-                FlickKeyModel<Extension>(labelType: .text(".,-/"), pressActions: [.input(".")], flickKeys: [
+                FlickKeyModel(labelType: .text(".,-/"), pressActions: [.input(".")], flickKeys: [
                     .left: FlickedKeyModel(
                         labelType: .text(","),
                         pressActions: [.input(",")]
@@ -618,9 +618,9 @@ struct FlickDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             ],
             // 第5列
             [
-                FlickKeyModel<Extension>.delete,
-                FlickSpaceKeyModel<Extension>.shared,
-                FlickEnterKeyModel<Extension>.shared
+                FlickKeyModel.delete,
+                FlickSpaceKeyModel.shared,
+                FlickEnterKeyModel.shared
             ]
         ]
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
@@ -14,11 +14,11 @@ struct FlickKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: V
     @State private var suggestState = FlickSuggestState()
 
     private let tabDesign: TabDependentDesign
-    private let models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)]
-    init(keyModels: [[any FlickKeyModelProtocol]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
+    private let models: [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)]
+    init(keyModels: [[any FlickKeyModelProtocol<Extension>]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
         self.tabDesign = TabDependentDesign(width: 5, height: 4, interfaceSize: interfaceSize, layout: .flick, orientation: keyboardOrientation)
 
-        var models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] = [:]
+        var models: [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)] = [:]
         for h in keyModels.indices {
             for v in keyModels[h].indices {
                 let model = keyModels[h][v]

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickAaKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickAaKeyModel.swift
@@ -40,7 +40,7 @@ struct FlickAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Fli
         }
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width)
         } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickChangeKeyboardKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickChangeKeyboardKeyModel.swift
@@ -45,7 +45,7 @@ struct FlickChangeKeyboardModel<Extension: ApplicationSpecificKeyboardViewExtens
         return [:]
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         switch SemiStaticStates.shared.needsInputModeSwitchKey {
         case true:
             return KeyLabel(.changeKeyboard, width: width)

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
@@ -30,7 +30,7 @@ struct FlickEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: 
         [:]
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         let text = Design.language.getEnterKeyText(states.enterKeyState)
         return KeyLabel(.text(text), width: width)
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKanaSymbolsKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKanaSymbolsKeyModel.swift
@@ -33,7 +33,7 @@ struct FlickKanaSymbolsKeyModel<Extension: ApplicationSpecificKeyboardViewExtens
 
     private init() {}
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModel.swift
@@ -53,7 +53,7 @@ struct FlickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Flick
         self.flickKeys
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModelProtocol.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModelProtocol.swift
@@ -44,9 +44,7 @@ public protocol FlickKeyModelProtocol<Extension> {
     @MainActor func flickKeys(variableStates: VariableStates) -> [FlickDirection: FlickedKeyModel]
     @MainActor func isFlickAble(to direction: FlickDirection, variableStates: VariableStates) -> Bool
 
-    // FIXME: any FlickKeyModelProtocolではassociatedtypeが扱いづらい問題に対処するため、任意のExtensionに対して扱えるようにする
-    // FIXME: iOS 16以降はany FlickKeyModelProtocol<Extension>を使って解消できる
-    @MainActor func label<Extension: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<Extension>
+    @MainActor func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension>
 
     @MainActor func flickSensitivity(to direction: FlickDirection) -> CGFloat
     @MainActor func feedback(variableStates: VariableStates)

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -28,7 +28,7 @@ enum KeyPressState {
 
 @MainActor
 public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
-    private let model: any FlickKeyModelProtocol
+    private let model: any FlickKeyModelProtocol<Extension>
 
     @State private var pressState: KeyPressState = .inactive
     @Binding private var suggestState: FlickSuggestState
@@ -42,7 +42,7 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
     private let size: CGSize
     private let position: (x: Int, y: Int)
 
-    init(model: any FlickKeyModelProtocol, size: CGSize, position: (x: Int, y: Int), suggestState: Binding<FlickSuggestState>) {
+    init(model: any FlickKeyModelProtocol<Extension>, size: CGSize, position: (x: Int, y: Int), suggestState: Binding<FlickSuggestState>) {
         self.model = model
         self.size = size
         self.position = position

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKogakiKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKogakiKeyModel.swift
@@ -35,7 +35,7 @@ struct FlickKogakiKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         .none
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickNextCandidateKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickNextCandidateKeyModel.swift
@@ -49,7 +49,7 @@ struct FlickNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExte
 
     private init() {}
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         if states.resultModel.results.isEmpty {
             KeyLabel(.text("空白"), width: width)
         } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickSpaceKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickSpaceKeyModel.swift
@@ -43,7 +43,7 @@ struct FlickSpaceKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: 
         .init(start: [.setCursorBar(.toggle)])
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(.text("空白"), width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickTabKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickTabKeyModel.swift
@@ -37,7 +37,7 @@ struct FlickTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Fl
         self.tab = tab
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.data.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
@@ -28,7 +28,7 @@ struct QwertyAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qw
         .init(start: [.setBoolState(VariableStates.BoolStates.isCapsLockedKey, .toggle)])
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
         } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyChangeKeyboardKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyChangeKeyboardKeyModel.swift
@@ -68,7 +68,7 @@ struct QwertyChangeKeyboardKeyModel<Extension: ApplicationSpecificKeyboardViewEx
         self.fallBackType = fallBackType
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if SemiStaticStates.shared.needsInputModeSwitchKey {
             return KeyLabel(.changeKeyboard, width: width, textColor: color)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyEnterKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyEnterKeyModel.swift
@@ -34,7 +34,7 @@ struct QwertyEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         .none
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         let text = Design.language.getEnterKeyText(states.enterKeyState)
         return KeyLabel(.text(text), width: width, textSize: .small, textColor: color)
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyFunctionalKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyFunctionalKeyModel.swift
@@ -38,7 +38,7 @@ struct QwertyFunctionalKeyModel<Extension: ApplicationSpecificKeyboardViewExtens
         self.longPressActions
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width, textColor: color)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
@@ -31,7 +31,7 @@ struct QwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qwer
         self.unpressedKeyColorType = keyColorType
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if (states.boolStates.isCapsLocked || states.boolStates.isShifted), states.keyboardLanguage == .en_US, case let .text(text) = self.labelType {
             return KeyLabel(.text(text.uppercased()), width: width, textColor: color)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModelProtocol.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModelProtocol.swift
@@ -92,7 +92,7 @@ protocol QwertyKeyModelProtocol<Extension> {
     @MainActor func longPressActions(variableStates: VariableStates) -> LongpressActionType
     /// 二回連続で押した際に発火するActionを指定する
     @MainActor func doublePressActions(variableStates: VariableStates) -> [ActionType]
-    @MainActor func label<Extension: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension>
+    @MainActor func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension>
     func backGroundColorWhenPressed(theme: Extension.Theme) -> Color
     var unpressedKeyColorType: QwertyUnpressedKeyColorType {get}
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -98,7 +98,7 @@ struct QwertyKeyDoublePressState {
 
 @MainActor
 struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
-    private let model: any QwertyKeyModelProtocol
+    private let model: any QwertyKeyModelProtocol<Extension>
     @EnvironmentObject private var variableStates: VariableStates
 
     @State private var pressState: QwertyKeyPressState = .unpressed
@@ -112,7 +112,7 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     private let tabDesign: TabDependentDesign
     private let size: CGSize
 
-    init(model: any QwertyKeyModelProtocol, tabDesign: TabDependentDesign, size: CGSize) {
+    init(model: any QwertyKeyModelProtocol<Extension>, tabDesign: TabDependentDesign, size: CGSize) {
         self.model = model
         self.tabDesign = tabDesign
         self.size = size
@@ -227,7 +227,7 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     }
 
     private func label(width: CGFloat, color: Color?) -> some View {
-        self.model.label(width: width, states: variableStates, color: color) as KeyLabel<Extension>
+        self.model.label(width: width, states: variableStates, color: color)
     }
 
     var body: some View {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
@@ -55,7 +55,7 @@ struct QwertySwitchLanguageKeyModel<Extension: ApplicationSpecificKeyboardViewEx
         self.languages = languages
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         let current = currentTabLanguage(variableStates: states)
         if languages.0 == current {
             return KeyLabel(.selectable(languages.0.symbol, languages.1.symbol), width: width, textColor: color)
@@ -64,7 +64,7 @@ struct QwertySwitchLanguageKeyModel<Extension: ApplicationSpecificKeyboardViewEx
         } else if SemiStaticStates.shared.needsInputModeSwitchKey {
             return KeyLabel(.text(states.keyboardLanguage.symbol), width: width, textColor: color)
         } else {
-            return KeyLabel(.text(E.SettingProvider.preferredLanguage.first.symbol), width: width, textColor: color)
+            return KeyLabel(.text(Extension.SettingProvider.preferredLanguage.first.symbol), width: width, textColor: color)
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyNextCandidateKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyNextCandidateKeyModel.swift
@@ -38,7 +38,7 @@ struct QwertyNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
         }
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.resultModel.results.isEmpty {
             switch states.keyboardLanguage {
             case .el_GR:

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
@@ -37,7 +37,7 @@ struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         }
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
         } else if states.boolStates.isShifted {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySpaceKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySpaceKeyModel.swift
@@ -18,7 +18,7 @@ struct QwertySpaceKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
 
     init() {}
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         switch states.keyboardLanguage {
         case .el_GR:
             return KeyLabel(.text("διάστημα"), width: width, textSize: .small, textColor: color)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
@@ -41,7 +41,7 @@ struct QwertyTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Q
         self.keySizeType = .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space)
     }
 
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         switch SemiStaticStates.shared.needsInputModeSwitchKey {
         case true:
             switch states.keyboardLanguage {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
@@ -15,7 +15,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
         let languageKey: any QwertyKeyModelProtocol<Extension>
         let first = preferredLanguage.first
         if let second = preferredLanguage.second {
-            languageKey = QwertySwitchLanguageKeyModel<Extension>(rowInfo: rowInfo, languages: (first, second))
+            languageKey = QwertySwitchLanguageKeyModel(rowInfo: rowInfo, languages: (first, second))
         } else {
             let targetTab: TabData = {
                 switch first {
@@ -27,17 +27,17 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     return .system(.user_japanese)
                 }
             }()
-            languageKey = QwertyFunctionalKeyModel<Extension>(labelType: .text(first.symbol), rowInfo: rowInfo, pressActions: [.moveTab(targetTab)], longPressActions: .none, needSuggestView: false)
+            languageKey = QwertyFunctionalKeyModel(labelType: .text(first.symbol), rowInfo: rowInfo, pressActions: [.moveTab(targetTab)], longPressActions: .none, needSuggestView: false)
         }
 
-        let numbersKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel<Extension>(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_numbers))], longPressActions: .init(start: [.setTabBar(.toggle)]))
-        let symbolsKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel<Extension>(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let numbersKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_numbers))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let symbolsKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
 
         let changeKeyboardKey: any QwertyKeyModelProtocol<Extension>
         if let second = preferredLanguage.second {
-            changeKeyboardKey = QwertyChangeKeyboardKeyModel<Extension>(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .secondTab(secondLanguage: second))
+            changeKeyboardKey = QwertyChangeKeyboardKeyModel(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .secondTab(secondLanguage: second))
         } else {
-            changeKeyboardKey = QwertyChangeKeyboardKeyModel<Extension>(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .tabBar)
+            changeKeyboardKey = QwertyChangeKeyboardKeyModel(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .tabBar)
         }
         return (
             languageKey: languageKey,

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
@@ -10,9 +10,9 @@ import Foundation
 import enum CustardKit.TabData
 
 struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
-    @MainActor static func tabKeys(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int)) -> (languageKey: any QwertyKeyModelProtocol, numbersKey: any QwertyKeyModelProtocol, symbolsKey: any QwertyKeyModelProtocol, changeKeyboardKey: any QwertyKeyModelProtocol) {
+    @MainActor static func tabKeys(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int)) -> (languageKey: any QwertyKeyModelProtocol<Extension>, numbersKey: any QwertyKeyModelProtocol<Extension>, symbolsKey: any QwertyKeyModelProtocol<Extension>, changeKeyboardKey: any QwertyKeyModelProtocol<Extension>) {
         let preferredLanguage = Extension.SettingProvider.preferredLanguage
-        let languageKey: any QwertyKeyModelProtocol
+        let languageKey: any QwertyKeyModelProtocol<Extension>
         let first = preferredLanguage.first
         if let second = preferredLanguage.second {
             languageKey = QwertySwitchLanguageKeyModel<Extension>(rowInfo: rowInfo, languages: (first, second))
@@ -30,10 +30,10 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             languageKey = QwertyFunctionalKeyModel<Extension>(labelType: .text(first.symbol), rowInfo: rowInfo, pressActions: [.moveTab(targetTab)], longPressActions: .none, needSuggestView: false)
         }
 
-        let numbersKey: any QwertyKeyModelProtocol = QwertyFunctionalKeyModel<Extension>(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_numbers))], longPressActions: .init(start: [.setTabBar(.toggle)]))
-        let symbolsKey: any QwertyKeyModelProtocol = QwertyFunctionalKeyModel<Extension>(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let numbersKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel<Extension>(labelType: .image("textformat.123"), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_numbers))], longPressActions: .init(start: [.setTabBar(.toggle)]))
+        let symbolsKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel<Extension>(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
 
-        let changeKeyboardKey: any QwertyKeyModelProtocol
+        let changeKeyboardKey: any QwertyKeyModelProtocol<Extension>
         if let second = preferredLanguage.second {
             changeKeyboardKey = QwertyChangeKeyboardKeyModel<Extension>(keySizeType: .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space), fallBackType: .secondTab(secondLanguage: second))
         } else {
@@ -48,9 +48,9 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
     }
 
     // 横に並べる
-    @MainActor static var numberKeyboard: [[any QwertyKeyModelProtocol]] {[
+    @MainActor static var numberKeyboard: [[any QwertyKeyModelProtocol<Extension>]] {[
         [
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("1"),
                 pressActions: [.input("1")],
                 variationsModel: VariationsModel([
@@ -61,7 +61,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
 
                 ], direction: .right)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("2"),
                 pressActions: [.input("2")],
                 variationsModel: VariationsModel([
@@ -72,7 +72,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
 
                 ], direction: .right)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("3"),
                 pressActions: [.input("3")],
                 variationsModel: VariationsModel([
@@ -83,7 +83,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
 
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("4"),
                 pressActions: [.input("4")],
                 variationsModel: VariationsModel([
@@ -93,7 +93,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("④"), actions: [.input("④")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("5"),
                 pressActions: [.input("5")],
                 variationsModel: VariationsModel([
@@ -103,7 +103,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("⑤"), actions: [.input("⑤")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("6"),
                 pressActions: [.input("6")],
                 variationsModel: VariationsModel([
@@ -113,7 +113,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("⑥"), actions: [.input("⑥")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("7"),
                 pressActions: [.input("7")],
                 variationsModel: VariationsModel([
@@ -123,7 +123,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("⑦"), actions: [.input("⑦")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("8"),
                 pressActions: [.input("8")],
                 variationsModel: VariationsModel([
@@ -133,7 +133,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("⑧"), actions: [.input("⑧")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("9"),
                 pressActions: [.input("9")],
                 variationsModel: VariationsModel([
@@ -143,7 +143,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("⑨"), actions: [.input("⑨")] )
                 ], direction: .left)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("0"),
                 pressActions: [.input("0")],
                 variationsModel: VariationsModel([
@@ -155,8 +155,8 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             )
         ],
         [
-            QwertyKeyModel<Extension>(labelType: .text("-"), pressActions: [.input("-")]),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(labelType: .text("-"), pressActions: [.input("-")]),
+            QwertyKeyModel(
                 labelType: .text("/"),
                 pressActions: [.input("/")],
                 variationsModel: VariationsModel([
@@ -164,7 +164,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("\\"), actions: [.input("\\")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text(":"),
                 pressActions: [.input(":")],
                 variationsModel: VariationsModel([
@@ -174,7 +174,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("；"), actions: [.input("；")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("@"),
                 pressActions: [.input("@")],
                 variationsModel: VariationsModel([
@@ -182,9 +182,9 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＠"), actions: [.input("＠")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(labelType: .text("("), pressActions: [.input("(")]),
-            QwertyKeyModel<Extension>(labelType: .text(")"), pressActions: [.input(")")]),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(labelType: .text("("), pressActions: [.input("(")]),
+            QwertyKeyModel(labelType: .text(")"), pressActions: [.input(")")]),
+            QwertyKeyModel(
                 labelType: .text("「"),
                 pressActions: [.input("「")],
                 variationsModel: VariationsModel([
@@ -195,7 +195,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("《"), actions: [.input("《")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("」"),
                 pressActions: [.input("」")],
                 variationsModel: VariationsModel([
@@ -206,7 +206,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("》"), actions: [.input("》")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("¥"),
                 pressActions: [.input("¥")],
                 variationsModel: VariationsModel([
@@ -220,7 +220,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("¤"), actions: [.input("¤")] )
                 ], direction: .left)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("&"),
                 pressActions: [.input("&")],
                 variationsModel: VariationsModel([
@@ -234,21 +234,21 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             Self.tabKeys(rowInfo: (7, 2, 0, 0)).symbolsKey
         ] + Extension.SettingProvider.numberTabCustomKeysSetting.compiled(extension: Extension.self) +
         [
-            QwertyFunctionalKeyModel<Extension>.delete
+            QwertyFunctionalKeyModel.delete
         ],
 
         [
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).languageKey,
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).changeKeyboardKey,
-            QwertyNextCandidateKeyModel<Extension>(),
-            QwertyEnterKeyModel<Extension>.shared
+            QwertyNextCandidateKeyModel(),
+            QwertyEnterKeyModel.shared
         ]
     ]
     }
     // 横に並べる
-    @MainActor static func symbolsKeyboard() -> [[any QwertyKeyModelProtocol]] {[
+    @MainActor static func symbolsKeyboard() -> [[any QwertyKeyModelProtocol<Extension>]] {[
         [
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("["),
                 pressActions: [.input("[")],
                 variationsModel: VariationsModel([
@@ -256,7 +256,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("［"), actions: [.input("［")])
                 ], direction: .right)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("]"),
                 pressActions: [.input("]")],
                 variationsModel: VariationsModel([
@@ -264,7 +264,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("］"), actions: [.input("］")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("{"),
                 pressActions: [.input("{")],
                 variationsModel: VariationsModel([
@@ -272,7 +272,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("｛"), actions: [.input("｛")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("}"),
                 pressActions: [.input("}")],
                 variationsModel: VariationsModel([
@@ -280,7 +280,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("｝"), actions: [.input("｝")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("#"),
                 pressActions: [.input("#")],
                 variationsModel: VariationsModel([
@@ -288,7 +288,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＃"), actions: [.input("＃")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("%"),
                 pressActions: [.input("%")],
                 variationsModel: VariationsModel([
@@ -296,7 +296,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("％"), actions: [.input("％")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("^"),
                 pressActions: [.input("^")],
                 variationsModel: VariationsModel([
@@ -304,7 +304,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＾"), actions: [.input("＾")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("*"),
                 pressActions: [.input("*")],
                 variationsModel: VariationsModel([
@@ -312,7 +312,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＊"), actions: [.input("＊")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("+"),
                 pressActions: [.input("+")],
                 variationsModel: VariationsModel([
@@ -321,7 +321,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("±"), actions: [.input("±")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("="),
                 pressActions: [.input("=")],
                 variationsModel: VariationsModel([
@@ -334,8 +334,8 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
             )
         ],
         [
-            QwertyKeyModel<Extension>(labelType: .text("_"), pressActions: [.input("_")]),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(labelType: .text("_"), pressActions: [.input("_")]),
+            QwertyKeyModel(
                 labelType: .text("\\"),
                 pressActions: [.input("\\")],
                 variationsModel: VariationsModel([
@@ -343,7 +343,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("\\"), actions: [.input("\\")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text(";"),
                 pressActions: [.input(";")],
                 variationsModel: VariationsModel([
@@ -353,7 +353,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("；"), actions: [.input("；")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("|"),
                 pressActions: [.input("|")],
                 variationsModel: VariationsModel([
@@ -361,7 +361,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("｜"), actions: [.input("｜")] )
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("<"),
                 pressActions: [.input("<")],
                 variationsModel: VariationsModel([
@@ -369,7 +369,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＜"), actions: [.input("＜")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text(">"),
                 pressActions: [.input(">")],
                 variationsModel: VariationsModel([
@@ -377,7 +377,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＞"), actions: [.input("＞")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("\""),
                 pressActions: [.input("\"")],
                 variationsModel: VariationsModel([
@@ -387,7 +387,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("”"), actions: [.input("”")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("'"),
                 pressActions: [.input("'")],
                 variationsModel: VariationsModel([
@@ -396,7 +396,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                 ])
             ),
 
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("$"),
                 pressActions: [.input("$")],
                 variationsModel: VariationsModel([
@@ -404,7 +404,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("＄"), actions: [.input("＄")])
                 ])
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("€"),
                 pressActions: [.input("€")],
                 variationsModel: VariationsModel([
@@ -422,7 +422,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
 
         [
             Self.tabKeys(rowInfo: (7, 2, 0, 0)).numbersKey,
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("."),
                 pressActions: [.input(".")],
                 variationsModel: VariationsModel([
@@ -431,7 +431,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                 ]),
                 for: (7, 5)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text(","),
                 pressActions: [.input(",")],
                 variationsModel: VariationsModel([
@@ -439,7 +439,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text(","), actions: [.input(",")] )
                 ]),
                 for: (7, 5)),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("?"),
                 pressActions: [.input("?")],
                 variationsModel: VariationsModel([
@@ -448,7 +448,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                 ]),
                 for: (7, 5)
             ),
-            QwertyKeyModel<Extension>(
+            QwertyKeyModel(
                 labelType: .text("!"),
                 pressActions: [.input("!")],
                 variationsModel: VariationsModel([
@@ -456,116 +456,116 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                     (label: .text("!"), actions: [.input("!")] )
                 ]),
                 for: (7, 5)),
-            QwertyKeyModel<Extension>(labelType: .text("・"), pressActions: [.input("…")], for: (7, 5)),
-            QwertyFunctionalKeyModel<Extension>.delete
+            QwertyKeyModel(labelType: .text("・"), pressActions: [.input("…")], for: (7, 5)),
+            QwertyFunctionalKeyModel.delete
         ],
         [
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).languageKey,
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).changeKeyboardKey,
-            QwertyNextCandidateKeyModel<Extension>(),
-            QwertyEnterKeyModel<Extension>.shared
+            QwertyNextCandidateKeyModel(),
+            QwertyEnterKeyModel.shared
         ]
     ]}
 
     // 横に並べる
-    @MainActor static func hiraKeyboard() -> [[any QwertyKeyModelProtocol]] {[
+    @MainActor static func hiraKeyboard() -> [[any QwertyKeyModelProtocol<Extension>]] {[
         [
-            QwertyKeyModel<Extension>(labelType: .text("q"), pressActions: [.input("q")]),
-            QwertyKeyModel<Extension>(labelType: .text("w"), pressActions: [.input("w")]),
-            QwertyKeyModel<Extension>(labelType: .text("e"), pressActions: [.input("e")]),
-            QwertyKeyModel<Extension>(labelType: .text("r"), pressActions: [.input("r")]),
-            QwertyKeyModel<Extension>(labelType: .text("t"), pressActions: [.input("t")]),
-            QwertyKeyModel<Extension>(labelType: .text("y"), pressActions: [.input("y")]),
-            QwertyKeyModel<Extension>(labelType: .text("u"), pressActions: [.input("u")]),
-            QwertyKeyModel<Extension>(labelType: .text("i"), pressActions: [.input("i")]),
-            QwertyKeyModel<Extension>(labelType: .text("o"), pressActions: [.input("o")]),
-            QwertyKeyModel<Extension>(labelType: .text("p"), pressActions: [.input("p")])
+            QwertyKeyModel(labelType: .text("q"), pressActions: [.input("q")]),
+            QwertyKeyModel(labelType: .text("w"), pressActions: [.input("w")]),
+            QwertyKeyModel(labelType: .text("e"), pressActions: [.input("e")]),
+            QwertyKeyModel(labelType: .text("r"), pressActions: [.input("r")]),
+            QwertyKeyModel(labelType: .text("t"), pressActions: [.input("t")]),
+            QwertyKeyModel(labelType: .text("y"), pressActions: [.input("y")]),
+            QwertyKeyModel(labelType: .text("u"), pressActions: [.input("u")]),
+            QwertyKeyModel(labelType: .text("i"), pressActions: [.input("i")]),
+            QwertyKeyModel(labelType: .text("o"), pressActions: [.input("o")]),
+            QwertyKeyModel(labelType: .text("p"), pressActions: [.input("p")])
         ],
         [
-            QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
-            QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
-            QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
-            QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
-            QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
-            QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
-            QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
-            QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
-            QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")]),
-            QwertyKeyModel<Extension>(labelType: .text("ー"), pressActions: [.input("ー")])
+            QwertyKeyModel(labelType: .text("a"), pressActions: [.input("a")]),
+            QwertyKeyModel(labelType: .text("s"), pressActions: [.input("s")]),
+            QwertyKeyModel(labelType: .text("d"), pressActions: [.input("d")]),
+            QwertyKeyModel(labelType: .text("f"), pressActions: [.input("f")]),
+            QwertyKeyModel(labelType: .text("g"), pressActions: [.input("g")]),
+            QwertyKeyModel(labelType: .text("h"), pressActions: [.input("h")]),
+            QwertyKeyModel(labelType: .text("j"), pressActions: [.input("j")]),
+            QwertyKeyModel(labelType: .text("k"), pressActions: [.input("k")]),
+            QwertyKeyModel(labelType: .text("l"), pressActions: [.input("l")]),
+            QwertyKeyModel(labelType: .text("ー"), pressActions: [.input("ー")])
         ],
         [
             Self.tabKeys(rowInfo: (7, 2, 0, 0)).languageKey,
-            QwertyKeyModel<Extension>(labelType: .text("z"), pressActions: [.input("z")]),
-            QwertyKeyModel<Extension>(labelType: .text("x"), pressActions: [.input("x")]),
-            QwertyKeyModel<Extension>(labelType: .text("c"), pressActions: [.input("c")]),
-            QwertyKeyModel<Extension>(labelType: .text("v"), pressActions: [.input("v")]),
-            QwertyKeyModel<Extension>(labelType: .text("b"), pressActions: [.input("b")]),
-            QwertyKeyModel<Extension>(labelType: .text("n"), pressActions: [.input("n")]),
-            QwertyKeyModel<Extension>(labelType: .text("m"), pressActions: [.input("m")]),
-            QwertyFunctionalKeyModel<Extension>.delete
+            QwertyKeyModel(labelType: .text("z"), pressActions: [.input("z")]),
+            QwertyKeyModel(labelType: .text("x"), pressActions: [.input("x")]),
+            QwertyKeyModel(labelType: .text("c"), pressActions: [.input("c")]),
+            QwertyKeyModel(labelType: .text("v"), pressActions: [.input("v")]),
+            QwertyKeyModel(labelType: .text("b"), pressActions: [.input("b")]),
+            QwertyKeyModel(labelType: .text("n"), pressActions: [.input("n")]),
+            QwertyKeyModel(labelType: .text("m"), pressActions: [.input("m")]),
+            QwertyFunctionalKeyModel.delete
         ],
         [
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).numbersKey,
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).changeKeyboardKey,
-            QwertyNextCandidateKeyModel<Extension>(),
-            QwertyEnterKeyModel<Extension>.shared
+            QwertyNextCandidateKeyModel(),
+            QwertyEnterKeyModel.shared
         ]
     ]}
 
     // 横に並べる
-    @MainActor static func abcKeyboard() -> [[any QwertyKeyModelProtocol]] {[
+    @MainActor static func abcKeyboard() -> [[any QwertyKeyModelProtocol<Extension>]] {[
         [
-            QwertyKeyModel<Extension>(labelType: .text("q"), pressActions: [.input("q")]),
-            QwertyKeyModel<Extension>(labelType: .text("w"), pressActions: [.input("w")]),
-            QwertyKeyModel<Extension>(labelType: .text("e"), pressActions: [.input("e")]),
-            QwertyKeyModel<Extension>(labelType: .text("r"), pressActions: [.input("r")]),
-            QwertyKeyModel<Extension>(labelType: .text("t"), pressActions: [.input("t")]),
-            QwertyKeyModel<Extension>(labelType: .text("y"), pressActions: [.input("y")]),
-            QwertyKeyModel<Extension>(labelType: .text("u"), pressActions: [.input("u")]),
-            QwertyKeyModel<Extension>(labelType: .text("i"), pressActions: [.input("i")]),
-            QwertyKeyModel<Extension>(labelType: .text("o"), pressActions: [.input("o")]),
-            QwertyKeyModel<Extension>(labelType: .text("p"), pressActions: [.input("p")])
+            QwertyKeyModel(labelType: .text("q"), pressActions: [.input("q")]),
+            QwertyKeyModel(labelType: .text("w"), pressActions: [.input("w")]),
+            QwertyKeyModel(labelType: .text("e"), pressActions: [.input("e")]),
+            QwertyKeyModel(labelType: .text("r"), pressActions: [.input("r")]),
+            QwertyKeyModel(labelType: .text("t"), pressActions: [.input("t")]),
+            QwertyKeyModel(labelType: .text("y"), pressActions: [.input("y")]),
+            QwertyKeyModel(labelType: .text("u"), pressActions: [.input("u")]),
+            QwertyKeyModel(labelType: .text("i"), pressActions: [.input("i")]),
+            QwertyKeyModel(labelType: .text("o"), pressActions: [.input("o")]),
+            QwertyKeyModel(labelType: .text("p"), pressActions: [.input("p")])
         ],
         Extension.SettingProvider.useShiftKey ?
             [
-                QwertyShiftKeyModel<Extension>.shared,
-                QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
-                QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
-                QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
-                QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
-                QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
-                QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
-                QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
-                QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
-                QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")])
+                QwertyShiftKeyModel.shared,
+                QwertyKeyModel(labelType: .text("a"), pressActions: [.input("a")]),
+                QwertyKeyModel(labelType: .text("s"), pressActions: [.input("s")]),
+                QwertyKeyModel(labelType: .text("d"), pressActions: [.input("d")]),
+                QwertyKeyModel(labelType: .text("f"), pressActions: [.input("f")]),
+                QwertyKeyModel(labelType: .text("g"), pressActions: [.input("g")]),
+                QwertyKeyModel(labelType: .text("h"), pressActions: [.input("h")]),
+                QwertyKeyModel(labelType: .text("j"), pressActions: [.input("j")]),
+                QwertyKeyModel(labelType: .text("k"), pressActions: [.input("k")]),
+                QwertyKeyModel(labelType: .text("l"), pressActions: [.input("l")])
             ] : [
-                QwertyKeyModel<Extension>(labelType: .text("a"), pressActions: [.input("a")]),
-                QwertyKeyModel<Extension>(labelType: .text("s"), pressActions: [.input("s")]),
-                QwertyKeyModel<Extension>(labelType: .text("d"), pressActions: [.input("d")]),
-                QwertyKeyModel<Extension>(labelType: .text("f"), pressActions: [.input("f")]),
-                QwertyKeyModel<Extension>(labelType: .text("g"), pressActions: [.input("g")]),
-                QwertyKeyModel<Extension>(labelType: .text("h"), pressActions: [.input("h")]),
-                QwertyKeyModel<Extension>(labelType: .text("j"), pressActions: [.input("j")]),
-                QwertyKeyModel<Extension>(labelType: .text("k"), pressActions: [.input("k")]),
-                QwertyKeyModel<Extension>(labelType: .text("l"), pressActions: [.input("l")]),
-                QwertyAaKeyModel<Extension>.shared
+                QwertyKeyModel(labelType: .text("a"), pressActions: [.input("a")]),
+                QwertyKeyModel(labelType: .text("s"), pressActions: [.input("s")]),
+                QwertyKeyModel(labelType: .text("d"), pressActions: [.input("d")]),
+                QwertyKeyModel(labelType: .text("f"), pressActions: [.input("f")]),
+                QwertyKeyModel(labelType: .text("g"), pressActions: [.input("g")]),
+                QwertyKeyModel(labelType: .text("h"), pressActions: [.input("h")]),
+                QwertyKeyModel(labelType: .text("j"), pressActions: [.input("j")]),
+                QwertyKeyModel(labelType: .text("k"), pressActions: [.input("k")]),
+                QwertyKeyModel(labelType: .text("l"), pressActions: [.input("l")]),
+                QwertyAaKeyModel.shared
             ],
         [
             Self.tabKeys(rowInfo: (7, 2, 0, 0)).languageKey,
-            QwertyKeyModel<Extension>(labelType: .text("z"), pressActions: [.input("z")]),
-            QwertyKeyModel<Extension>(labelType: .text("x"), pressActions: [.input("x")]),
-            QwertyKeyModel<Extension>(labelType: .text("c"), pressActions: [.input("c")]),
-            QwertyKeyModel<Extension>(labelType: .text("v"), pressActions: [.input("v")]),
-            QwertyKeyModel<Extension>(labelType: .text("b"), pressActions: [.input("b")]),
-            QwertyKeyModel<Extension>(labelType: .text("n"), pressActions: [.input("n")]),
-            QwertyKeyModel<Extension>(labelType: .text("m"), pressActions: [.input("m")]),
-            QwertyFunctionalKeyModel<Extension>.delete
+            QwertyKeyModel(labelType: .text("z"), pressActions: [.input("z")]),
+            QwertyKeyModel(labelType: .text("x"), pressActions: [.input("x")]),
+            QwertyKeyModel(labelType: .text("c"), pressActions: [.input("c")]),
+            QwertyKeyModel(labelType: .text("v"), pressActions: [.input("v")]),
+            QwertyKeyModel(labelType: .text("b"), pressActions: [.input("b")]),
+            QwertyKeyModel(labelType: .text("n"), pressActions: [.input("n")]),
+            QwertyKeyModel(labelType: .text("m"), pressActions: [.input("m")]),
+            QwertyFunctionalKeyModel.delete
         ],
         [
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).numbersKey,
             Self.tabKeys(rowInfo: (0, 2, 1, 1)).changeKeyboardKey,
-            QwertyNextCandidateKeyModel<Extension>(),
-            QwertyEnterKeyModel<Extension>.shared
+            QwertyNextCandidateKeyModel(),
+            QwertyEnterKeyModel.shared
         ]
     ]}
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
 struct QwertyKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let tabDesign: TabDependentDesign
-    private let keyModels: [[any QwertyKeyModelProtocol]]
+    private let keyModels: [[any QwertyKeyModelProtocol<Extension>]]
 
-    init(keyModels: [[any QwertyKeyModelProtocol]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
+    init(keyModels: [[any QwertyKeyModelProtocol<Extension>]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
         self.keyModels = keyModels
         self.tabDesign = TabDependentDesign(width: 10, height: 4, interfaceSize: interfaceSize, layout: .qwerty, orientation: keyboardOrientation)
     }
@@ -32,7 +32,7 @@ struct QwertyKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
                 HStack(spacing: tabDesign.horizontalSpacing) {
                     ForEach(self.horizontalIndices(v: v), id: \.self) {(h: Int) in
                         let model = self.keyModels[v][h]
-                        QwertyKeyView<Extension>(
+                        QwertyKeyView(
                             model: model,
                             tabDesign: tabDesign,
                             size: CGSize(

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -366,7 +366,7 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 private struct ExpandKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: SimpleKeyModelProtocol {
     private var currentLevel: EmojiTabExpandModePreference.Level
     private var action: () -> Void
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(.image(self.currentLevel.icon), width: width, textSize: .max)
     }
 
@@ -393,7 +393,7 @@ private struct ExpandKeyModel<Extension: ApplicationSpecificKeyboardViewExtensio
 private struct GenreKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: SimpleKeyModelProtocol {
     private var action: () -> Void
     private var systemImage: String
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(.image(systemImage), width: width, textSize: .max)
     }
 
@@ -432,7 +432,7 @@ private struct EmojiKeyModel<Extension: ApplicationSpecificKeyboardViewExtension
     var longPressActions: LongpressActionType {
         .none
     }
-    func label<E: ApplicationSpecificKeyboardViewExtension>(width: CGFloat, states _: VariableStates, theme _: ThemeData<some ApplicationSpecificTheme>) -> KeyLabel<E> {
+    func label(width: CGFloat, states _: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(.text(emoji), width: width, textSize: .max)
     }
 

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -47,7 +47,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
     @Binding private var manager: CustardManager
     @State private var showPreview = false
     @State private var copiedKey: UserMadeTenKeyCustard.KeyData?
-    private var models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] {
+    private var models: [KeyPosition: (model: any FlickKeyModelProtocol<AzooKeyKeyboardViewExtension>, width: Int, height: Int)] {
         (0..<layout.rowCount).reduce(into: [:]) {dict, x in
             (0..<layout.columnCount).forEach {y in
                 if let value = editingItem.keys[.gridFit(x: x, y: y)] {


### PR DESCRIPTION
#317 の一環。type-safeになったのと、書き方の冗長性が減らせた。