### PR TITLE
[Feature] デザインを改善

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
@@ -18,6 +18,7 @@ public struct AzooKeyIcon: View {
         case king
         case santaClaus
         case strawHat
+        case fire
     }
     public enum Color {
         case auto
@@ -88,6 +89,9 @@ public struct AzooKeyIcon: View {
                 Text("\u{EA22}")
                     .foregroundStyle(.red)
             }
+        case .fire:
+            Text("δ")
+                .foregroundStyle(foregroundColor)
         }
     }
 

--- a/MainApp/Customize/CustomizeTabWalkthrough.swift
+++ b/MainApp/Customize/CustomizeTabWalkthrough.swift
@@ -84,6 +84,7 @@ struct CustomizeTabWalkthroughView: View {
                         }
                         .buttonStyle(LargeButtonStyle(backgroundColor: .blue))
                         .foregroundStyle(.white)
+                        .padding(.horizontal, 20)
                         .padding(.top, 30)
                     }
                     .background(Color.background)

--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -44,57 +44,89 @@ struct EditingTabBarView: View {
         self._manager = manager
     }
 
+    private static let anchorId = "BOTTOM_ANCHOR"
     var body: some View {
-        Form {
-            Text("タブバーを編集し、タブの並び替え、削除、追加を行ったり、文字の入力やカーソルの移動など様々な機能を追加することができます。")
-            Section {
-                Button(action: add) {
-                    Label("アイテムを追加", systemImage: "plus")
-                }
-            }
-            Section(header: Text("アイテム")) {
-                DisclosuringList($items) { $item in
-                    HStack {
-                        Label("ラベル", systemImage: "rectangle.and.pencil.and.ellipsis")
-                        Spacer()
-                        TabNavigationViewItemLabelEditView("ラベルを設定", label: $item.label)
-                    }
-                    NavigationLink(destination: CodableActionDataEditor($item.actions, availableCustards: manager.availableCustards)) {
-                        Label("アクション", systemImage: "terminal")
-
-                        Text(makeLabelText(item: item))
-                            .foregroundStyle(.gray)
-                    }
-                } label: { item in
-                    label(labelType: item.label)
-                        .contextMenu {
-                            Button(role: .destructive) {
-                                items.removeAll(where: {$0.id == item.id})
-                            } label: {
-                                Label("削除", systemImage: "trash")
-                            }
+        ScrollViewReader { proxy in
+            Form {
+                Text("タブバーを編集し、タブの並び替え、削除、追加を行ったり、文字の入力やカーソルの移動など様々な機能を追加することができます。")
+                Section {
+                    Button("アイテムを追加", systemImage: "plus") {
+                        withAnimation(.interactiveSpring()) {
+                            let item = EditingTabBarItem(
+                                label: .text("アイテム"),
+                                actions: [.moveTab(.system(.user_japanese))]
+                            )
+                            self.items.append(item)
+                            proxy.scrollTo(Self.anchorId, anchor: .bottom)
                         }
+                    }
                 }
-                .onDelete(perform: delete)
-                .onMove(perform: move)
-            }
-        }
-        .onAppear {
-            if let tabBarData = try? manager.tabbar(identifier: 0), tabBarData.lastUpdateDate != self.lastUpdateDate {
-                self.items = tabBarData.items.indices.map {i in
-                    EditingTabBarItem(
-                        label: tabBarData.items[i].label,
-                        actions: tabBarData.items[i].actions
-                    )
+                Section(header: Text("アイテム")) {
+                    DisclosuringList($items) { $item in
+                        HStack {
+                            Label("ラベル", systemImage: "rectangle.and.pencil.and.ellipsis")
+                            Spacer()
+                            TabNavigationViewItemLabelEditView("ラベルを設定", label: $item.label)
+                        }
+                        NavigationLink(destination: CodableActionDataEditor($item.actions, availableCustards: manager.availableCustards)) {
+                            Label("アクション", systemImage: "terminal")
+                            Text(makeLabelText(item: item))
+                                .foregroundStyle(.gray)
+                        }
+                    } label: { item in
+                        label(labelType: item.label)
+                            .contextMenu {
+                                Button(role: .destructive) {
+                                    items.removeAll(where: {$0.id == item.id})
+                                } label: {
+                                    Label("削除", systemImage: "trash")
+                                }
+                            }
+                    }
+                    .onDelete(perform: delete)
+                    .onMove(perform: move)
+                }
+                Section(header: Text("便利なボタンを追加")) {
+                    Button("片手モードをオン", systemImage: "aspectratio") {
+                        withAnimation(.interactiveSpring()) {
+                            self.items.append(EditingTabBarItem(label: .text("片手"), actions: [.enableResizingMode]))
+                        }
+                    }
+                    .id(Self.anchorId)  // ココに付けると自動スクロールが機能する
+                    Button("絵文字タブを表示", systemImage: "face.smiling") {
+                        withAnimation(.interactiveSpring()) {
+                            self.items.append(EditingTabBarItem(label: .text("絵文字"), actions: [.moveTab(.system(.emoji_tab))]))
+                        }
+                    }
+                    Button("カーソルバーを表示", systemImage: "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right") {
+                        withAnimation(.interactiveSpring()) {
+                            self.items.append(EditingTabBarItem(label: .text("カーソル移動"), actions: [.toggleCursorBar]))
+                        }
+                    }
+                    Button("キーボードを閉じる", systemImage: "keyboard.chevron.compact.down") {
+                        withAnimation(.interactiveSpring()) {
+                            self.items.append(EditingTabBarItem(label: .text("閉じる"), actions: [.dismissKeyboard]))
+                        }
+                    }
                 }
             }
+            .onAppear {
+                if let tabBarData = try? manager.tabbar(identifier: 0), tabBarData.lastUpdateDate != self.lastUpdateDate {
+                    self.items = tabBarData.items.indices.map {i in
+                        EditingTabBarItem(
+                            label: tabBarData.items[i].label,
+                            actions: tabBarData.items[i].actions
+                        )
+                    }
+                }
+            }
+            .onChange(of: items) {newValue in
+                self.save(newValue)
+            }
+            .navigationBarTitle(Text("タブバーの編集"), displayMode: .inline)
+            .navigationBarItems(trailing: editButton)
+            .environment(\.editMode, $editMode)
         }
-        .onChange(of: items) {newValue in
-            self.save(newValue)
-        }
-        .navigationBarTitle(Text("タブバーの編集"), displayMode: .inline)
-        .navigationBarItems(trailing: editButton)
-        .environment(\.editMode, $editMode)
     }
 
     @ViewBuilder private func label(labelType: TabBarItemLabelType) -> some View {
@@ -149,23 +181,12 @@ struct EditingTabBarView: View {
         } label: {
             switch editMode {
             case .inactive:
-                Text("削除と順番")
+                Text("編集")
             case .active, .transient:
                 Text("完了")
             @unknown default:
                 Text("完了")
             }
-        }
-    }
-
-    private func add() {
-        withAnimation(Animation.interactiveSpring()) {
-            items.append(
-                EditingTabBarItem(
-                    label: .text("アイテム"),
-                    actions: [.moveTab(.system(.user_japanese))]
-                )
-            )
         }
     }
 

--- a/MainApp/EnableAzooKeyView/EnableAzooKeyView.swift
+++ b/MainApp/EnableAzooKeyView/EnableAzooKeyView.swift
@@ -62,9 +62,13 @@ struct EnableAzooKeyView: View {
                             EnableAzooKeyViewHeader("追加する")
                             EnableAzooKeyViewText("下にスクロールして「追加する」を押して", with: "plus.circle")
                             EnableAzooKeyViewText("「キーボード」を押して", with: "keyboard")
-                            EnableAzooKeyViewImage(.initSettingKeyboardImageHand)
+                            CenterAlignedView {
+                                EnableAzooKeyViewImage(.initSettingKeyboardImageHand)
+                            }
                             EnableAzooKeyViewText("azooKeyをオンにして", with: "square.and.line.vertical.and.square.fill")
-                            EnableAzooKeyViewImage(.initSettingAzooKeySwitchImageHand)
+                            CenterAlignedView {
+                                EnableAzooKeyViewImage(.initSettingAzooKeySwitchImageHand)
+                            }
                             EnableAzooKeyViewText("このアプリを再び開いてください", with: "arrow.turn.down.left")
                             CenterAlignedView {
                                 EnableAzooKeyViewButton("追加する", systemName: "plus.circle") {
@@ -134,7 +138,9 @@ struct EnableAzooKeyView: View {
                                     appStates.requireFirstOpenView = false
                                 }
                             if !showDoneMessage {
-                                EnableAzooKeyViewImage(.initSettingGlobeTap)
+                                CenterAlignedView {
+                                    EnableAzooKeyViewImage(.initSettingGlobeTap)
+                                }
                             }
                             EnableAzooKeyViewText("azooKeyをお楽しみください！", with: "star.fill")
                             if !showDoneMessage {

--- a/MainApp/EnableAzooKeyView/EnableAzooKeyViewComponent.swift
+++ b/MainApp/EnableAzooKeyView/EnableAzooKeyViewComponent.swift
@@ -100,5 +100,6 @@ struct EnableAzooKeyViewImage: View {
             .resizable()
             .scaledToFit()
             .cornerRadius(2)
+            .frame(maxWidth: MainAppDesign.imageMaximumWidth)
     }
 }

--- a/MainApp/General/Focus.swift
+++ b/MainApp/General/Focus.swift
@@ -18,17 +18,14 @@ private struct FocusViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         let shadowColor = focused ? color : .clear
-        let shadowRadius: CGFloat = focused ? 0.5 : .zero
+        let shadowRadius: CGFloat = focused ? 3.0 : .zero
         return content
-            .shadow(color: shadowColor, radius: shadowRadius, x: 1)
-            .shadow(color: shadowColor, radius: shadowRadius, x: -1)
-            .shadow(color: shadowColor, radius: shadowRadius, y: 1)
-            .shadow(color: shadowColor, radius: shadowRadius, y: -1)
+            .shadow(color: shadowColor, radius: shadowRadius)
     }
 }
 
 extension View {
-    func focus(_ color: Color, focused: Bool) -> some View {
+    func focus(_ color: Color = .accentColor, focused: Bool) -> some View {
         self.modifier(FocusViewModifier(color: color, focused: focused))
     }
 }

--- a/MainApp/General/HeaderLogoView.swift
+++ b/MainApp/General/HeaderLogoView.swift
@@ -33,7 +33,9 @@ struct HeaderLogoView: View {
             }
         }
         .foregroundStyle(iconColor)
-        .padding(.top, 5)
-        .padding(.bottom, -5)
     }
+}
+
+#Preview {
+    HeaderLogoView()
 }

--- a/MainApp/General/LargeButtonStyle.swift
+++ b/MainApp/General/LargeButtonStyle.swift
@@ -10,19 +10,17 @@ import SwiftUI
 
 struct LargeButtonStyle: ButtonStyle {
     private let backgroundColor: Color
-    private let screenWidth: CGFloat
     @MainActor init(backgroundColor: Color) {
         self.backgroundColor = backgroundColor
-        self.screenWidth = UIScreen.main.bounds.width
     }
     @ViewBuilder func makeBody(configuration: Configuration) -> some View {
         configuration
             .label
             .font(.body.bold())
             .padding()
-            .frame(width: screenWidth * 0.9)
+            .frame(maxWidth: .infinity)
             .background(
-                RoundedRectangle(cornerRadius: screenWidth / 4.8 * 0.17)
+                RoundedRectangle(cornerRadius: 12)
                     .fill(backgroundColor)
             )
             .opacity(configuration.isPressed ? 0.8 : 1)

--- a/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
+++ b/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
@@ -39,6 +39,7 @@ struct CustomKeySettingFlickKeyView<Label: View>: View {
         RoundedRectangle(cornerRadius: 10)
             .stroke(strokeColor)
             .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+            .compositingGroup()
             .focus(.accentColor, focused: focused)
             .overlay(label())
             .onTapGesture {

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -165,6 +165,7 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(strokeColor)
                         .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+                        .compositingGroup()
                         .focus(.accentColor, focused: isSelected && selection.longpressSelectIndex == -1)
                         .focus(.systemGray, focused: isSelected && selection.longpressSelectIndex != -1)
                         .overlay(Text(item.name))
@@ -179,6 +180,7 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                         RoundedRectangle(cornerRadius: 10)
                             .stroke(isSelected ? Color.accentColor : .primary)
                             .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+                            .compositingGroup()
                             .focus(.accentColor, focused: isSelected)
                             .overlay(Text(item.name))
                     }

--- a/MainApp/Setting/OpenSourceSoftwaresLicenseView.swift
+++ b/MainApp/Setting/OpenSourceSoftwaresLicenseView.swift
@@ -193,7 +193,7 @@ struct OpenSourceSoftwaresLicenseView: View {
             }
             Section {
                 HStack {
-                    AzooKeyIcon(fontSize: 60)
+                    FunnyAzooKeyIcon()
                     Spacer()
                     Text("azooKeyを使ってくれてありがとう！")
                 }
@@ -201,5 +201,112 @@ struct OpenSourceSoftwaresLicenseView: View {
         }
         .multilineTextAlignment(.leading)
         .navigationBarTitle(Text("オープンソースソフトウェア"), displayMode: .inline)
+    }
+}
+
+private struct FunnyAzooKeyIcon: View {
+    init(stage: Stage = .normal) {
+        self._stage = .init(initialValue: stage)
+    }
+    
+    struct NormalAnimationValue {
+        // degrees
+        var angle: Double = -10
+    }
+    struct KingAnimationValue {
+        // degrees
+        var yAngle: Double = -10
+        var scale: Double = 1.0
+    }
+    struct FireAnimationValue {
+        // degrees
+        var yAngle: Double = 0
+        var scale: Double = 1.0
+    }
+    enum Stage {
+        case normal
+        case king
+        case fire
+    }
+    @Namespace private var namespace
+    @State private var stage: Stage = .normal
+
+    private var iconCore: some View {
+        AzooKeyIcon(fontSize: 60)
+            .matchedGeometryEffect(id: "icon", in: namespace)
+    }
+
+    var body: some View {
+        if #available(iOS 17, *) {
+            switch stage {
+            case .normal:
+                iconCore
+                    .keyframeAnimator(initialValue: NormalAnimationValue()) { content, value in
+                        content
+                            .rotationEffect(Angle(degrees: value.angle))
+                    } keyframes: { _ in
+                            KeyframeTrack(\.angle) {
+                                CubicKeyframe(10, duration: 0.5)
+                                CubicKeyframe(-10, duration: 0.5)
+                            }
+                    }
+                    .onTapGesture {
+                        withAnimation {
+                            self.stage = Bool.random() ? .king : .fire
+                        }
+                    }
+            case .king:
+                AzooKeyIcon(fontSize: 60, looks: .king)
+                    .matchedGeometryEffect(id: "icon", in: namespace)
+                    .keyframeAnimator(initialValue: KingAnimationValue()) { content, value in
+                        content
+                            .rotationEffect(Angle(degrees: value.yAngle))
+                            .scaleEffect(value.scale)
+                    } keyframes: { _ in
+                        KeyframeTrack(\.yAngle) {
+                            CubicKeyframe(10, duration: 0.5)
+                            CubicKeyframe(-10, duration: 0.5)
+                        }
+                        KeyframeTrack(\.scale) {
+                            SpringKeyframe(1, duration: 0.2)
+                            SpringKeyframe(1.4, duration: 0.6)
+                            SpringKeyframe(1, duration: 0.2)
+                        }
+                    }
+                    .onTapGesture {
+                        withAnimation {
+                            self.stage = .normal
+                        }
+                    }
+            case .fire:
+                AzooKeyIcon(fontSize: 60, looks: .fire)
+                    .matchedGeometryEffect(id: "icon", in: namespace)
+                    .keyframeAnimator(initialValue: FireAnimationValue()) { content, value in
+                        content
+                            .rotationEffect(Angle(degrees: value.yAngle))
+                            .scaleEffect(value.scale)
+                    } keyframes: { _ in
+                        KeyframeTrack(\.yAngle) {
+                            SpringKeyframe(20, duration: 0.8)
+                            CubicKeyframe(0, duration: 0.2)
+                        }
+                    }
+                    .onTapGesture {
+                        withAnimation {
+                            self.stage = .normal
+                        }
+                    }
+            }
+        } else {
+            iconCore
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        FunnyAzooKeyIcon(stage: .normal)
+        FunnyAzooKeyIcon(stage: .king)
+        FunnyAzooKeyIcon(stage: .fire)
     }
 }

--- a/MainApp/Tips/TipsView.swift
+++ b/MainApp/Tips/TipsView.swift
@@ -14,56 +14,59 @@ struct TipsTabView: View {
     @AppStorage("read_article_iOS15_service_termination") private var readArticle_iOS15_service_termination = false
 
     var body: some View {
-        VStack {
-            HeaderLogoView()
-            NavigationView {
-                Form {
-                    Section(header: Text("キーボードを使えるようにする")) {
-                        if !appStates.isKeyboardActivated {
-                            Text("キーボードを有効化する")
-                                .onTapGesture {
-                                    appStates.requireFirstOpenView = true
-                                }
-                        }
-                        NavigationLink("入力方法を選ぶ", destination: SelctInputStyleTipsView())
-                    }
-                    if #unavailable(iOS 16) {
-                        Section(header: Text("お知らせ")) {
-                            HStack {
-                                if !readArticle_iOS15_service_termination {
-                                    Image(systemName: "exclamationmark.circle.fill")
-                                        .foregroundStyle(.red)
-                                }
-                                NavigationLink("iOS15のサポートを終了します", destination: iOS15TerminationNewsView($readArticle_iOS15_service_termination))
+        NavigationView {
+            Form {
+                Section(header: Text("キーボードを使えるようにする")) {
+                    if !appStates.isKeyboardActivated {
+                        Text("キーボードを有効化する")
+                            .onTapGesture {
+                                appStates.requireFirstOpenView = true
                             }
-                        }
                     }
-
-                    Section(header: Text("便利な使い方")) {
-                        NavigationLink("片手モードを使う", destination: OneHandedModeTipsView())
-                        NavigationLink("カーソルを自由に移動する", destination: CursorMoveTipsView())
-                        NavigationLink("文頭まで一気に消す", destination: SmoothDeleteTipsView())
-                        NavigationLink("漢字を拡大表示する", destination: KanjiLargeTextTipsView())
-                        NavigationLink("大文字に固定する", destination: CapsLockTipsView())
-                        NavigationLink("タイムスタンプを使う", destination: TemplateSettingTipsView())
-                        NavigationLink("キーをカスタマイズする", destination: CustomKeyTipsView())
-                        NavigationLink("フルアクセスが必要な機能を使う", destination: FullAccessTipsView())
-                        if SemiStaticStates.shared.hasFullAccess {
-                            NavigationLink("「ほかのAppからペースト」について", destination: PasteFromOtherAppsPermissionTipsView())
+                    NavigationLink("入力方法を選ぶ", destination: SelctInputStyleTipsView())
+                }
+                if #unavailable(iOS 16) {
+                    Section(header: Text("お知らせ")) {
+                        HStack {
+                            if !readArticle_iOS15_service_termination {
+                                Image(systemName: "exclamationmark.circle.fill")
+                                    .foregroundStyle(.red)
+                            }
+                            NavigationLink("iOS15のサポートを終了します", destination: iOS15TerminationNewsView($readArticle_iOS15_service_termination))
                         }
-                    }
-
-                    Section(header: Text("困ったときは")) {
-                        NavigationLink("インストール直後、特定のアプリでキーボードが開かない", destination: KeyboardBehaviorIssueAfterInstallTipsView())
-                        NavigationLink("特定のアプリケーションで入力がおかしくなる", destination: UseMarkedTextTipsView())
-                        NavigationLink("端末の文字サイズ設定が反映されない", destination: DynamicTypeSettingFailureTipsView())
-                        NavigationLink("絵文字や顔文字の変換候補を表示したい", destination: EmojiKaomojiTipsView())
-                        NavigationLink("バグの報告や機能のリクエストをしたい", destination: ContactView())
                     }
                 }
-                .navigationBarTitle(Text("使い方"), displayMode: .large)
+
+                Section(header: Text("便利な使い方")) {
+                    NavigationLink("片手モードを使う", destination: OneHandedModeTipsView())
+                    NavigationLink("カーソルを自由に移動する", destination: CursorMoveTipsView())
+                    NavigationLink("文頭まで一気に消す", destination: SmoothDeleteTipsView())
+                    NavigationLink("漢字を拡大表示する", destination: KanjiLargeTextTipsView())
+                    NavigationLink("大文字に固定する", destination: CapsLockTipsView())
+                    NavigationLink("タイムスタンプを使う", destination: TemplateSettingTipsView())
+                    NavigationLink("キーをカスタマイズする", destination: CustomKeyTipsView())
+                    NavigationLink("フルアクセスが必要な機能を使う", destination: FullAccessTipsView())
+                    if SemiStaticStates.shared.hasFullAccess {
+                        NavigationLink("「ほかのAppからペースト」について", destination: PasteFromOtherAppsPermissionTipsView())
+                    }
+                }
+
+                Section(header: Text("困ったときは")) {
+                    NavigationLink("インストール直後、特定のアプリでキーボードが開かない", destination: KeyboardBehaviorIssueAfterInstallTipsView())
+                    NavigationLink("特定のアプリケーションで入力がおかしくなる", destination: UseMarkedTextTipsView())
+                    NavigationLink("端末の文字サイズ設定が反映されない", destination: DynamicTypeSettingFailureTipsView())
+                    NavigationLink("絵文字や顔文字の変換候補を表示したい", destination: EmojiKaomojiTipsView())
+                    NavigationLink("バグの報告や機能のリクエストをしたい", destination: ContactView())
+                }
             }
-            .navigationViewStyle(.stack)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    HeaderLogoView()
+                        .padding(.vertical, 4)
+                }
+            }
         }
+        .navigationViewStyle(.stack)
     }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1925,6 +1925,16 @@
         }
       }
     },
+    "カーソルバーを表示" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show cursor bar"
+          }
+        }
+      }
+    },
     "カーソルを移動する" : {
       "localizations" : {
         "en" : {
@@ -5356,6 +5366,16 @@
         }
       }
     },
+    "便利なボタンを追加" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add useful buttons"
+          }
+        }
+      }
+    },
     "便利な使い方" : {
       "localizations" : {
         "en" : {
@@ -8522,6 +8542,16 @@
         }
       }
     },
+    "絵文字タブを表示" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show emoji tab"
+          }
+        }
+      }
+    },
     "絵文字と顔文字" : {
       "localizations" : {
         "en" : {
@@ -8598,6 +8628,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
+          }
+        }
+      }
+    },
+    "編集" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         }
       }


### PR DESCRIPTION
* AckのViewでazooKeyのアイコンが動くようにした(iOS 17+)
* focusの実装を調整し、より美しいshadowが付くようにした
* tab barの編集中にアイテムを追加した際、画面が下にスクロールするようにした
* tips viewのヘッダーにlogoを表示する方法をよりSwiftUI-nativeにした