### PR TITLE
[Fix] CursorBar周りを整えた

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -162,19 +162,19 @@ public final class VariableStates: ObservableObject {
 
     @Published public var undoAction: UndoAction?
 
-    @Published var moveCursorBarState = SliderStyleCursorBarState()
-
-    @Published private(set) var leftSideText: String = ""
-    @Published private(set) var centerText: String = ""
-    @Published private(set) var rightSideText: String = ""
+    struct SurroundingText: Equatable, Hashable, Sendable {
+        var leftSideText: String = ""
+        var centerText: String = ""
+        var rightSideText: String = ""
+    }
+    @Published private(set) var surroundingText = SurroundingText()
 
     @Published public var temporalMessage: TemporalMessage?
 
     public func setSurroundingText(leftSide: String, center: String, rightSide: String) {
-        self.leftSideText = leftSide
-        self.centerText = center
-        self.rightSideText = rightSide
-        self.moveCursorBarState.updateLine(leftText: leftSide + center, rightText: rightSide)
+        self.surroundingText.leftSideText = leftSide
+        self.surroundingText.centerText = center
+        self.surroundingText.rightSideText = rightSide
     }
 
     @MainActor public func setResizingMode(_ state: ResizingState) {
@@ -197,7 +197,6 @@ public final class VariableStates: ObservableObject {
 
     @MainActor public func initialize() {
         self.tabManager.initialize(variableStates: self)
-        self.moveCursorBarState.clear()
     }
 
     @MainActor public func closeKeyboard() {

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftUIUtils
 import SwiftUtils
 
-struct SliderStyleCursorBarState: Equatable {
+private struct CursorBarState: Equatable, Hashable, Sendable {
     private(set) var displayLeftIndex = 0
     private(set) var displayRightIndex = 0
     fileprivate var line: [String] = []
@@ -25,10 +25,10 @@ struct SliderStyleCursorBarState: Equatable {
     }
 
     mutating func updateLine(leftText: String, rightText: String) {
-        debug("updateLine", leftText, rightText, itemCount, line)
+        debug("CursorBarState.updateLine", leftText, rightText, itemCount, line)
         var left = leftText.map {String($0)}
-        if left.first == "\n" {
-            left.removeFirst()
+        if let index = left.firstIndex(of: "\n"), index != left.endIndex - 1 {
+            left.removeFirst(index + 1)
         }
         self.line = left + rightText.map {String($0)} + ["⏎"]
         self.displayLeftIndex = left.count - itemCount / 2
@@ -43,6 +43,10 @@ struct SliderStyleCursorBarState: Equatable {
     }
 
     @MainActor mutating fileprivate func move(_ count: Int, actionManager: some UserActionManager, variableStates: VariableStates) {
+        if centerIndex + count < -1 || line.count < centerIndex + count {
+            debug("CursorBarState.move rejected", centerIndex, count, line)
+            return
+        }
         displayLeftIndex += count
         displayRightIndex += count
         actionManager.registerAction(.moveCursor(count), variableStates: variableStates)
@@ -67,7 +71,6 @@ struct SliderStyleCursorBarState: Equatable {
     }
 }
 
-@MainActor
 struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     init() {}
 
@@ -75,23 +78,30 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
     @Environment(Extension.Theme.self) private var theme
     @Environment(\.userActionManager) private var action
 
-    enum SwipeGestureState {
+    private enum SwipeGestureState {
         case inactive
         case tap(l1: CGPoint, l2: CGPoint, l3: CGPoint)
         case moving(l1: CGPoint, l2: CGPoint, l3: CGPoint, count: Double)
     }
     @State private var swipeGestureState: SwipeGestureState = .inactive
+    @State private var cursorBarState = CursorBarState()
 
+    @MainActor
     private var fontSize: CGFloat {
         Design.fonts.resultViewFontSize(userPrefrerence: Extension.SettingProvider.resultViewFontSize)
     }
+
+    @MainActor
     fileprivate var itemWidth: CGFloat {
         fontSize * 1.3
     }
+
+    @MainActor
     fileprivate var viewWidth: CGFloat {
         variableStates.interfaceSize.width * 0.85
     }
 
+    @MainActor
     var swipeGesture: some Gesture {
         DragGesture(minimumDistance: 0, coordinateSpace: .global)
             .onChanged {value in
@@ -132,11 +142,11 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                     }
                     withAnimation(.linear(duration: 0.05)) {
                         if count >= 15 {
-                            variableStates.moveCursorBarState.move(1, actionManager: self.action, variableStates: variableStates)
+                            cursorBarState.move(1, actionManager: self.action, variableStates: variableStates)
                             count -= 15
                         }
                         if count <= -15 {
-                            variableStates.moveCursorBarState.move(-1, actionManager: self.action, variableStates: variableStates)
+                            cursorBarState.move(-1, actionManager: self.action, variableStates: variableStates)
                             count += 15
                         }
                         swipeGestureState = .moving(l1: value.location, l2: l1, l3: l2, count: count)
@@ -159,9 +169,9 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                     let offset_double = diff_from_center / itemWidth
                     // center indexからのoffsetになる
                     let offset = Int(offset_double.rounded(.toNearestOrAwayFromZero))
-                    let index = variableStates.moveCursorBarState.centerIndex + offset
+                    let index = cursorBarState.centerIndex + offset
                     withAnimation(.easeOut(duration: 0.1)) {
-                        variableStates.moveCursorBarState.tap(at: index, actionManager: self.action, variableStates: variableStates)
+                        cursorBarState.tap(at: index, actionManager: self.action, variableStates: variableStates)
                     }
                 case .moving:
                     // 位置を揃える
@@ -187,6 +197,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
         theme.resultTextColor.color
     }
 
+    @MainActor
     private var background: some View {
         RadialGradient(gradient: Gradient(colors: [centerColor, edgeColor]), center: .center, startRadius: 1, endRadius: viewWidth / 2)
             // TODO: ここからframeを消して問題なかったかチェックする
@@ -198,22 +209,31 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
         .system(size: size, weight: symbolsFontWeight, design: .default)
     }
 
+    @MainActor
     private var textView: some View {
         HStack(spacing: .zero) {
             // 多めに描画しておく
-            ForEach(variableStates.moveCursorBarState.displayLeftIndex - 4 ..< variableStates.moveCursorBarState.displayRightIndex + 4, id: \.self) { i in
-                Text(verbatim: variableStates.moveCursorBarState.getItem(at: i))
+            ForEach(cursorBarState.displayLeftIndex - 4 ..< cursorBarState.displayRightIndex + 4, id: \.self) { i in
+                let item = cursorBarState.getItem(at: i)
+                let hash = {
+                    var hasher = Hasher()
+                    hasher.combine(i)
+                    hasher.combine(item)
+                    return hasher.finalize()
+                }()
+                Text(verbatim: item)
                     .font(.system(size: fontSize).bold())
                     .frame(width: itemWidth)
+                    .id(hash)
             }
         }
         .allowsHitTesting(false)
         .foregroundStyle(theme.resultTextColor.color.opacity(0.4))
-        .drawingGroup()
         .frame(width: viewWidth)
         .clipped()
     }
 
+    @MainActor
     private var foregroundButtons: some View {
         ZStack(alignment: .center) {
             textView
@@ -234,7 +254,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                             self.action.registerLongPressActionEnd(.init(start: [], repeat: [.moveCursor(-1)]))
                             if gestureState.time < 0.4 {
                                 withAnimation(.linear(duration: 0.15)) {
-                                    variableStates.moveCursorBarState.move(-1, actionManager: self.action, variableStates: variableStates)
+                                    cursorBarState.move(-1, actionManager: self.action, variableStates: variableStates)
                                 }
                             }
                         }
@@ -260,7 +280,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                             self.action.registerLongPressActionEnd(.init(start: [], repeat: [.moveCursor(1)]))
                             if gestureState.time < 0.4 {
                                 withAnimation(.linear(duration: 0.15)) {
-                                    variableStates.moveCursorBarState.move(1, actionManager: self.action, variableStates: variableStates)
+                                    cursorBarState.move(1, actionManager: self.action, variableStates: variableStates)
                                 }
                             }
                         }
@@ -273,7 +293,14 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
         background
             .overlay(foregroundButtons)
             .onAppear {
-                variableStates.moveCursorBarState.updateItemCount(viewWidth: viewWidth, itemWidth: itemWidth)
+                cursorBarState.updateItemCount(viewWidth: viewWidth, itemWidth: itemWidth)
+                let surroundingText = variableStates.surroundingText
+                cursorBarState.updateLine(leftText: surroundingText.leftSideText + surroundingText.centerText, rightText: surroundingText.rightSideText)
+            }
+            .onChange(of: variableStates.surroundingText) { newValue in
+                withAnimation(.easeOut(duration: 0.1)) {
+                    cursorBarState.updateLine(leftText: newValue.leftSideText + newValue.centerText, rightText: newValue.rightSideText)
+                }
             }
     }
 }

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -806,6 +806,15 @@ import UIKit
         return [.setCursorBar(.off), .setTabBar(.off)]
     }
 
+    /// ユーザが行を跨いでカーソルを動かした場合に利用する
+    func userJumpedCursor() -> [ActionType] {
+        if self.composingText.isEmpty {
+            return [.setCursorBar(.on)]
+        }
+        self.stopComposition()
+        return []
+    }
+
     /// ユーザがキーボードを経由せずカットした場合の処理
     func userCutText(text: String) {
         self.stopComposition()

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -524,7 +524,6 @@ import SwiftUtils
     /// 何かが変化した後に状態を比較し、どのような変化が起こったのか判断する関数。
     override func notifySomethingDidChange(a_left: String, a_center: String, a_right: String, variableStates: VariableStates) {
         defer {
-            // moveCursorBarStateの更新
             variableStates.setSurroundingText(leftSide: a_left, center: a_center, rightSide: a_right)
             // エンターキーの状態の更新
             variableStates.setEnterKeyState(self.inputManager.getEnterKeyState())
@@ -669,9 +668,10 @@ import SwiftUtils
             return
         }
 
-        // 上記のどれにも引っかからず、なおかつテキスト全体が変更された場合
+        // 上記のどれにも引っかからず、なおかつテキスト全体が変更された場合→ユーザがカーソルをジャンプした
         debug("user operation id: 10, \((a_left, a_center, a_right)), \((b_left, b_center, b_right))")
-        self.inputManager.stopComposition()
+        let actions = self.inputManager.userJumpedCursor()
+        self.registerActions(actions, variableStates: variableStates)
     }
 
     private func hideLearningMemory() {


### PR DESCRIPTION
コミットがごちゃごちゃになってしまった。
* Fix #334 （原因はdrawingGroup()だった）
* Reflect StyleのCursor Bar StateをVariableStatesに持たせていたのをやめた
* 行を跨ぐケースで #277 が動作しない問題を修正
* Reflect Styleのカーソルバーで文字がガチャガチャと移動する問題を緩和した