### PR TITLE
[Design] 余白をKeyboardLayout非依存にした

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -15,25 +15,22 @@ import SwiftUIUtils
 public struct TabDependentDesign {
     let horizontalKeyCount: CGFloat
     let verticalKeyCount: CGFloat
-    let layout: KeyboardLayout
     let orientation: KeyboardOrientation
 
     private var interfaceWidth: CGFloat
     private var interfaceHeight: CGFloat
 
-    public init(width: Int, height: Int, interfaceSize: CGSize, layout: KeyboardLayout, orientation: KeyboardOrientation) {
+    public init(width: Int, height: Int, interfaceSize: CGSize, orientation: KeyboardOrientation) {
         self.horizontalKeyCount = CGFloat(width)
         self.verticalKeyCount = CGFloat(height)
-        self.layout = layout
         self.orientation = orientation
         self.interfaceWidth = interfaceSize.width
         self.interfaceHeight = interfaceSize.height
     }
 
-    public init(width: CGFloat, height: CGFloat, interfaceSize: CGSize, layout: KeyboardLayout, orientation: KeyboardOrientation) {
+    public init(width: CGFloat, height: CGFloat, interfaceSize: CGSize, orientation: KeyboardOrientation) {
         self.horizontalKeyCount = width
         self.verticalKeyCount = height
-        self.layout = layout
         self.orientation = orientation
         self.interfaceWidth = interfaceSize.width
         self.interfaceHeight = interfaceSize.height
@@ -42,10 +39,10 @@ public struct TabDependentDesign {
     /// screenWidthとhorizontalKeyCountに依存
     var keyViewWidth: CGFloat {
         let coefficient: CGFloat
-        switch (layout, orientation) {
-        case (_, .vertical):
+        switch orientation {
+        case .vertical:
             coefficient = 5 / (5.1 + horizontalKeyCount / 10)
-        case (_, .horizontal):
+        case .horizontal:
             coefficient = 10 / (10.2 + horizontalKeyCount * 0.28)
         }
         return interfaceWidth / horizontalKeyCount * coefficient
@@ -72,15 +69,11 @@ public struct TabDependentDesign {
     }
 
     var verticalSpacing: CGFloat {
-        switch (layout, orientation) {
-        case (.flick, .vertical):
-            return interfaceWidth * 3 / 140
-        case (.flick, .horizontal):
+        switch orientation {
+        case .vertical:
+            return interfaceWidth / 50
+        case .horizontal:
             return interfaceWidth / 107
-        case (.qwerty, .vertical):
-            return interfaceWidth / 36.6
-        case (.qwerty, .horizontal):
-            return interfaceWidth / 65
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -49,13 +49,13 @@ fileprivate extension CustardInterface {
     func tabDesign(interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) -> TabDependentDesign {
         switch self.keyLayout {
         case let .gridFit(value):
-            return TabDependentDesign(width: value.rowCount, height: value.columnCount, interfaceSize: interfaceSize, layout: keyStyle.keyboardLayout, orientation: keyboardOrientation)
+            return TabDependentDesign(width: value.rowCount, height: value.columnCount, interfaceSize: interfaceSize, orientation: keyboardOrientation)
         case let .gridScroll(value):
             switch value.direction {
             case .vertical:
-                return TabDependentDesign(width: CGFloat(Int(value.rowCount)), height: CGFloat(value.columnCount), interfaceSize: interfaceSize, layout: .flick, orientation: keyboardOrientation)
+                return TabDependentDesign(width: CGFloat(Int(value.rowCount)), height: CGFloat(value.columnCount), interfaceSize: interfaceSize, orientation: keyboardOrientation)
             case .horizontal:
-                return TabDependentDesign(width: CGFloat(value.rowCount), height: CGFloat(Int(value.columnCount)), interfaceSize: interfaceSize, layout: .flick, orientation: keyboardOrientation)
+                return TabDependentDesign(width: CGFloat(value.rowCount), height: CGFloat(Int(value.columnCount)), interfaceSize: interfaceSize, orientation: keyboardOrientation)
             }
         }
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/FlickKeyboardView.swift
@@ -16,7 +16,7 @@ struct FlickKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: V
     private let tabDesign: TabDependentDesign
     private let models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)]
     init(keyModels: [[any FlickKeyModelProtocol]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
-        self.tabDesign = TabDependentDesign(width: 5, height: 4, interfaceSize: interfaceSize, layout: .flick, orientation: keyboardOrientation)
+        self.tabDesign = TabDependentDesign(width: 5, height: 4, interfaceSize: interfaceSize, orientation: keyboardOrientation)
 
         var models: [KeyPosition: (model: any FlickKeyModelProtocol, width: Int, height: Int)] = [:]
         for h in keyModels.indices {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
@@ -15,7 +15,7 @@ struct QwertyKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
 
     init(keyModels: [[any QwertyKeyModelProtocol]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
         self.keyModels = keyModels
-        self.tabDesign = TabDependentDesign(width: 10, height: 4, interfaceSize: interfaceSize, layout: .qwerty, orientation: keyboardOrientation)
+        self.tabDesign = TabDependentDesign(width: 10, height: 4, interfaceSize: interfaceSize, orientation: keyboardOrientation)
     }
 
     private var verticalIndices: Range<Int> {

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
@@ -209,7 +209,7 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
                 VStack {
                     listView
                     HStack {
-                        let design = TabDependentDesign(width: 2, height: 7, interfaceSize: variableStates.interfaceSize, layout: .flick, orientation: .vertical)
+                        let design = TabDependentDesign(width: 2, height: 7, interfaceSize: variableStates.interfaceSize, orientation: .vertical)
                         enterKey(design)
                         deleteKey(design)
                     }
@@ -218,7 +218,7 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
                 HStack {
                     listView
                     VStack {
-                        let design = TabDependentDesign(width: 8, height: 2, interfaceSize: variableStates.interfaceSize, layout: .flick, orientation: .horizontal)
+                        let design = TabDependentDesign(width: 8, height: 2, interfaceSize: variableStates.interfaceSize, orientation: .horizontal)
                         deleteKey(design)
                         enterKey(design)
                     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -154,7 +154,7 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 
     /// 参考用
     private var keysHeight: CGFloat {
-        TabDependentDesign(width: 1, height: 1, interfaceSize: variableStates.interfaceSize, layout: .qwerty, orientation: variableStates.keyboardOrientation).keysHeight
+        TabDependentDesign(width: 1, height: 1, interfaceSize: variableStates.interfaceSize, orientation: variableStates.keyboardOrientation).keysHeight
     }
 
     private var scrollViewHeight: CGFloat {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -150,7 +150,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
                         }
                         Toggle("自動的にタブバーに追加", isOn: $editingItem.addTabBarAutomatically)
                     }
-                    CustardFlickKeysView<AzooKeyKeyboardViewExtension, _>(models: models, tabDesign: .init(width: layout.rowCount, height: layout.columnCount, interfaceSize: interfaceSize, layout: .flick, orientation: MainAppDesign.keyboardOrientation), layout: layout) {(view: FlickKeyView<AzooKeyKeyboardViewExtension>, x: Int, y: Int) in
+                    CustardFlickKeysView<AzooKeyKeyboardViewExtension, _>(models: models, tabDesign: .init(width: layout.rowCount, height: layout.columnCount, interfaceSize: interfaceSize, orientation: MainAppDesign.keyboardOrientation), layout: layout) {(view: FlickKeyView<AzooKeyKeyboardViewExtension>, x: Int, y: Int) in
                         if editingItem.emptyKeys.contains(.gridFit(x: x, y: y)) {
                             if !isCovered(at: (x, y)) {
                                 Button {


### PR DESCRIPTION
レイアウトの計算からKeyboardLayoutへの依存性を抜いた。これによって端末によって微妙にキーサイズやスペーシングが変わるが、多くの場合は気づかないと思う。