### PR TITLE
[Bug] Slackで絵文字が二重に入力され得る問題を修正

### DIFF
--- a/Keyboard/Display/DisplayedTextManager.swift
+++ b/Keyboard/Display/DisplayedTextManager.swift
@@ -280,7 +280,17 @@ import UIKit
             // (挿入): 愛[|してる]
             // (挿入): 愛[|してる]
             // (移動): 愛[してる|]
-            // 選択中でない場合、削除する
+            // (例３): [愛してる|] (「愛してる」をライブ変換しており、そのまま確定)
+            // (何もしない)
+            defer {
+                self.composingText = composingText
+                self.displayedLiveConversionText = nil
+            }
+            // 例３のケース
+            if composingText.isEmpty && completedPrefix == self.displayedLiveConversionText {
+                return
+            }
+            // 選択中でない場合、必要なだけ削除を実行する
             if !isSelected {
                 let count = self.displayedLiveConversionText?.count ?? self.composingText.convertTargetCursorPosition
                 self.deleteBackward(count: count)
@@ -289,8 +299,6 @@ import UIKit
             let cursorPosition = self.composingText.convertTargetCursorPosition - delta
             self.insertText(completedPrefix + String(self.composingText.convertTargetBeforeCursor.suffix(cursorPosition)))
             self.moveCursor(count: composingText.convertTargetCursorPosition - cursorPosition)
-            self.composingText = composingText
-            self.displayedLiveConversionText = nil
         }
     }
 }


### PR DESCRIPTION
Slackで「天使の輪→😇」のような変換を実行すると、「😇 😇」のように絵文字が二重に入力される不具合があった。

この問題はSlack側が絵文字の直後に半角スペースを追加することによりazooKey側の確定時の再入力操作で辻褄が合わなくなり、挙動がおかしくなることが原因だった。そこで確定操作のタイミングで実行する処理を変更し、不必要な場面で再入力処理が実行されないようにした。