### PR TITLE
[Feature] シフトキーの配置を改善

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyKeyboardViewExtension.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyKeyboardViewExtension.swift
@@ -98,6 +98,10 @@ public enum AzooKeyKeyboardViewExtension: ApplicationSpecificKeyboardViewExtensi
         UseShiftKey.value
     }
 
+    public static var keepDeprecatedShiftKeyBehavior: Bool {
+        KeepDeprecatedShiftKeyBehavior.value
+    }
+
     public static var useNextCandidateKey: Bool {
         UseNextCandidateKey.value
     }

--- a/AzooKeyCore/Sources/AzooKeyUtils/KeyboardSetting/BoolKeyboardSetting.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/KeyboardSetting/BoolKeyboardSetting.swift
@@ -201,6 +201,17 @@ public extension KeyboardSettingKey where Self == UseShiftKey {
     static var useShiftKey: Self { .init() }
 }
 
+public struct KeepDeprecatedShiftKeyBehavior: BoolKeyboardSettingKey {
+    public static let title: LocalizedStringKey = "シフトキーの古い挙動を使う"
+    public static let explanation: LocalizedStringKey = "シフトキーの以前の挙動を利用します。iOS 18以降では廃止されます。"
+    public static var defaultValue: Bool = true
+    public static let key: String = "keep_deprecated_shift_key_behavior"
+}
+
+public extension KeyboardSettingKey where Self == KeepDeprecatedShiftKeyBehavior {
+    static var keepDeprecatedShiftKeyBehavior: Self { .init() }
+}
+
 public struct UseNextCandidateKey: BoolKeyboardSettingKey {
     public static let title: LocalizedStringKey = "次候補キーを使う"
     public static let explanation: LocalizedStringKey = "キーボードで入力中、空白キーに「次候補」機能を表示します"

--- a/AzooKeyCore/Sources/AzooKeyUtils/SharedStore.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/SharedStore.swift
@@ -84,6 +84,7 @@ public enum SharedStore {
 }
 
 public extension AppVersion {
+    static let azooKey_v2_2_2 = AppVersion("2.2.2")!
     static let azooKey_v2_0_2 = AppVersion("2.0.2")!
     static let azooKey_v1_9 = AppVersion("1.9")!
     static let azooKey_v1_8_1 = AppVersion("1.8.1")!

--- a/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewSettingProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewSettingProvider.swift
@@ -30,6 +30,7 @@ import Foundation
     static var enablePasteButton: Bool { get }
     static var hideResetButtonInOneHandedMode: Bool { get }
     static var useShiftKey: Bool { get }
+    static var keepDeprecatedShiftKeyBehavior: Bool { get }
     static var useNextCandidateKey: Bool { get }
 
     /// タブバーボタンを表示する

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
@@ -8,10 +8,14 @@
 import SwiftUI
 
 struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
+    init(keySizeType: QwertyKeySizeType = .normal(of: 1, for: 1)) {
+        self.keySizeType = keySizeType
+    }
+    
     static var shared: Self { QwertyShiftKeyModel() }
 
-    let keySizeType: QwertyKeySizeType = .normal(of: 1, for: 1)
-    var variationsModel = VariationsModel([])
+    let keySizeType: QwertyKeySizeType
+    let variationsModel = VariationsModel([])
 
     let needSuggestView: Bool = false
 

--- a/MainApp/MainApp.swift
+++ b/MainApp/MainApp.swift
@@ -68,6 +68,11 @@ struct MainApp: App {
                     messageManager.getMessagesContainerAppShouldMakeWhichDone().forEach {
                         messageManager.done($0.id)
                     }
+                    // 設定を上書きする
+                    if let initialVersion = SharedStore.initialAppVersion, initialVersion > .azooKey_v2_2_2 {
+                        // Version 2.2.3以降にインストールしたユーザにはこのオプションを有効化しない
+                        KeepDeprecatedShiftKeyBehavior.value = false
+                    }
                 }
         }
     }

--- a/MainApp/Setting/SettingTab.swift
+++ b/MainApp/Setting/SettingTab.swift
@@ -56,7 +56,7 @@ struct SettingTabView: View {
                     if self.canQwertyLayout(appStates.englishLayout) {
                         BoolSettingView(.useShiftKey)
                         // Version 2.2.2以前にインストールしており、UseShiftKey.valueがtrueの人にのみこのオプションを表示する
-                        if let initialVersion = SharedStore.initialAppVersion, initialVersion <= .azooKey_v2_2_2, UseShiftKey.value == true {
+                        if #unavailable(iOS 18), let initialVersion = SharedStore.initialAppVersion, initialVersion <= .azooKey_v2_2_2, UseShiftKey.value == true {
                             BoolSettingView(.keepDeprecatedShiftKeyBehavior)
                         }
                     }

--- a/MainApp/Setting/SettingTab.swift
+++ b/MainApp/Setting/SettingTab.swift
@@ -55,6 +55,10 @@ struct SettingTabView: View {
                     }
                     if self.canQwertyLayout(appStates.englishLayout) {
                         BoolSettingView(.useShiftKey)
+                        // Version 2.2.2以前にインストールしており、UseShiftKey.valueがtrueの人にのみこのオプションを表示する
+                        if let initialVersion = SharedStore.initialAppVersion, initialVersion <= .azooKey_v2_2_2, UseShiftKey.value == true {
+                            BoolSettingView(.keepDeprecatedShiftKeyBehavior)
+                        }
                     }
                     if !SemiStaticStates.shared.needsInputModeSwitchKey, self.canFlickLayout(appStates.japaneseLayout) {
                         BoolSettingView(.enablePasteButton)


### PR DESCRIPTION
Resolve #379 

* シフトキーをVersion 2.2で導入したが、位置がイマイチでキーがガタガタ動いていた
* そこでVersion 2.2.3以降はデフォルトでシフトキーの位置を左下にすることで、この問題を解決した（leftbottom）
  * 既存のシフトキーのユーザは設定アプリで「シフトキーの古い挙動を使う」をオフにすることで、新しいバージョンのシフトキーを利用できる
  * iOS 18以降はこの挙動を完全に廃止する
  * 新規のユーザ（Version 2.2.3以降にダウンロードした人）は「シフトキーの古い挙動を使う」オプションは存在せず、初めからleftbottomで表示する

leftbottomの場合にピリオドキーを配置したのに合わせて、日本語キーの「ー」の長押しに句読点などを配置した