### PR TITLE
[Refactoring] キーボードの可変幅対応

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/SemiStaticStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/SemiStaticStates.swift
@@ -38,19 +38,10 @@ public final class SemiStaticStates {
         self.hasFullAccess = bool
     }
 
-    /// - do not  consider using screenHeight
-    /// - スクリーンそのもののサイズ。キーボードビューの幅は片手モードなどによって変更が生じうるため、`screenWidth`は限定的な場面でのみ使うことが望まし。
-    private(set) public var screenWidth: CGFloat = 0
     private(set) public var keyboardHeightScale: CGFloat = 1
 
     /// - note: キーボードが開かれたタイミングで一度呼ぶのが望ましい。
     public func setKeyboardHeightScale(_ scale: CGFloat) {
         self.keyboardHeightScale = scale
-    }
-
-    /// Function to set the width of area of keyboard
-    /// - Parameter width: 使用可能な領域の幅.
-    public func setScreenWidth(_ width: CGFloat) {
-        self.screenWidth = width
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/TabManager.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/TabManager.swift
@@ -188,7 +188,7 @@ public struct TabManager {
 
     @MainActor mutating private func moveTab(to destination: Tab.ExistentialTab, variableStates: VariableStates) {
         // VariableStateの状態を遷移先のタブに合わせて適切に変更する
-        variableStates.setKeyboardLayout(destination.layout)
+        variableStates.setKeyboardLayout(destination.layout, screenWidth: variableStates.screenWidth)
         variableStates.setInputStyle(destination.inputStyle)
         if let language = destination.language {
             variableStates.keyboardLanguage = language
@@ -202,7 +202,7 @@ public struct TabManager {
 
     @MainActor private func updateVariableStates(_ variableStates: VariableStates, layout: KeyboardLayout, inputStyle: InputStyle, language: KeyboardLanguage?) {
         // VariableStateの状態を遷移先のタブに合わせて適切に変更する
-        variableStates.setKeyboardLayout(layout)
+        variableStates.setKeyboardLayout(layout, screenWidth: variableStates.screenWidth)
         variableStates.setInputStyle(inputStyle)
         if let language {
             variableStates.keyboardLanguage = language

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ExpandedResultView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ExpandedResultView.swift
@@ -18,10 +18,18 @@ struct ExpandedResultView<Extension: ApplicationSpecificKeyboardViewExtension>: 
         Self.registerResults(results: variableStates.resultModel.results, interfaceWidth: variableStates.interfaceSize.width)
     }
     private var buttonWidth: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.5
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.5
     }
     private var buttonHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.6
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.6
     }
 
     @Environment(Extension.Theme.self) private var theme

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
@@ -22,7 +22,16 @@ struct LargeTextView: View {
     }
 
     private var font: Font {
-        Font.system(size: Design.largeTextViewFontSize(text, upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation), weight: .regular, design: .serif)
+        Font.system(
+            size: Design.largeTextViewFontSize(
+                text,
+                upsideComponent: variableStates.upsideComponent,
+                orientation: variableStates.keyboardOrientation,
+                screenWidth: variableStates.screenWidth
+            ),
+            weight: .regular,
+            design: .serif
+        )
     }
     var body: some View {
         VStack {
@@ -34,9 +43,23 @@ struct LargeTextView: View {
                 isViewOpen = false
             } label: {
                 Label("閉じる", systemImage: "xmark")
-            }.frame(width: nil, height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation) * 0.15)
+            }.frame(
+                width: nil,
+                height: Design.keyboardScreenHeight(
+                    upsideComponent: variableStates.upsideComponent,
+                    orientation: variableStates.keyboardOrientation,
+                    screenWidth: variableStates.screenWidth
+                ) * 0.15
+            )
         }
         .background(Color.background)
-        .frame(height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation), alignment: .bottom)
+        .frame(
+            height: Design.keyboardScreenHeight(
+                upsideComponent: variableStates.upsideComponent,
+                orientation: variableStates.keyboardOrientation,
+                screenWidth: variableStates.screenWidth
+            ),
+            alignment: .bottom
+        )
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -261,9 +261,9 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                 }
                 Button {
                     if self.position == .zero && self.size == self.initialSize {
-                        variableStates.setResizingMode(.fullwidth)
+                        variableStates.setResizingMode(.fullwidth, screenWidth: variableStates.screenWidth)
                     } else {
-                        variableStates.setResizingMode(.onehanded)
+                        variableStates.setResizingMode(.onehanded, screenWidth: variableStates.screenWidth)
                     }
                 }label: {
                     Circle()
@@ -328,7 +328,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
             let max = min(initialSize.width, initialSize.height) * 0.15
             let r = min(data.max * 0.7, max)
             let button1 = Button {
-                variableStates.setResizingMode(.resizing)
+                variableStates.setResizingMode(.resizing, screenWidth: variableStates.screenWidth)
             }label: {
                 Circle()
                     .fill(Color.blue)
@@ -342,7 +342,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
             .frame(width: r, height: r)
 
             let button2 = Button {
-                variableStates.setResizingMode(.fullwidth)
+                variableStates.setResizingMode(.fullwidth, screenWidth: variableStates.screenWidth)
             }label: {
                 Circle()
                     .fill(Color.blue)
@@ -361,7 +361,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     self.position = .zero
                     self.size.width = initialSize.width
                     self.size.height = initialSize.height
-                    variableStates.setResizingMode(.fullwidth)
+                    variableStates.setResizingMode(.fullwidth, screenWidth: variableStates.screenWidth)
                 }
                 variableStates.keyboardInternalSettingManager.update(\.oneHandedModeSetting) {value in
                     value.set(layout: variableStates.keyboardLayout, orientation: variableStates.keyboardOrientation, size: initialSize, position: .zero)

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -307,9 +307,9 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
 
     private func qwertyKeyData(x: Int, y: Int, size: QwertyKeySizeType) -> (position: CGPoint, size: CGSize) {
         let width = size.width(design: tabDesign)
-        let height = size.height(design: tabDesign)
+        let height = size.height(design: tabDesign, screenWidth: variableStates.screenWidth)
         let dx = width * 0.5 + tabDesign.keyViewWidth * CGFloat(x) + tabDesign.horizontalSpacing * CGFloat(x)
-        let dy = height * 0.5 + tabDesign.keyViewHeight * CGFloat(y) + tabDesign.verticalSpacing * CGFloat(y)
+        let dy = height * 0.5 + tabDesign.keyViewHeight(screenWidth: variableStates.screenWidth) * CGFloat(y) + tabDesign.verticalSpacing * CGFloat(y)
         return (CGPoint(x: dx, y: dy), CGSize(width: width, height: height))
     }
 
@@ -332,11 +332,11 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
                                     .position(x: info.position.x, y: info.position.y)
                             }
                         }
-                    }.frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight)
+                    }.frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight(screenWidth: variableStates.screenWidth))
                 }
             }
         case let .gridScroll(value):
-            let height = tabDesign.keysHeight
+            let height = tabDesign.keysHeight(screenWidth: variableStates.screenWidth)
             let models = (0..<custard.interface.keys.count).compactMap {custard.interface.keys[.gridScroll(GridScrollPositionSpecifier($0))]}
             switch value.direction {
             case .vertical:
@@ -349,7 +349,7 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
                     }
                 }.frame(height: height)
             case .horizontal:
-                let gridItem = GridItem(.fixed(tabDesign.keyViewHeight), spacing: tabDesign.verticalSpacing / 2)
+                let gridItem = GridItem(.fixed(tabDesign.keyViewHeight(screenWidth: variableStates.screenWidth)), spacing: tabDesign.verticalSpacing / 2)
                 ScrollView(.horizontal) {
                     LazyHGrid(rows: Array(repeating: gridItem, count: Int(value.columnCount)), spacing: tabDesign.horizontalSpacing / 2) {
                         ForEach(0..<models.count, id: \.self) {i in
@@ -364,6 +364,7 @@ struct CustomKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
 
 public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExtension, Content: View>: View {
     @State private var suggestState = FlickSuggestState()
+    @EnvironmentObject private var variableStates: VariableStates
 
     public init(models: [KeyPosition: (model: any FlickKeyModelProtocol<Extension>, width: Int, height: Int)], tabDesign: TabDependentDesign, layout: CustardInterfaceLayoutGridValue, blur: Bool = false, @ViewBuilder generator: @escaping (FlickKeyView<Extension>, Int, Int) -> (Content)) {
         self.models = models
@@ -381,9 +382,9 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
 
     @MainActor private func flickKeyData(x: Int, y: Int, width: Int, height: Int) -> (position: CGPoint, size: CGSize) {
         let width = tabDesign.keyViewWidth(widthCount: width)
-        let height = tabDesign.keyViewHeight(heightCount: height)
+        let height = tabDesign.keyViewHeight(heightCount: height, screenWidth: variableStates.screenWidth)
         let dx = width * 0.5 + tabDesign.keyViewWidth * CGFloat(x) + tabDesign.horizontalSpacing * CGFloat(x)
-        let dy = height * 0.5 + tabDesign.keyViewHeight * CGFloat(y) + tabDesign.verticalSpacing * CGFloat(y)
+        let dy = height * 0.5 + tabDesign.keyViewHeight(screenWidth: variableStates.screenWidth) * CGFloat(y) + tabDesign.verticalSpacing * CGFloat(y)
         return (CGPoint(x: dx, y: dy), CGSize(width: width, height: height))
     }
 
@@ -414,7 +415,7 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
                 .zIndex(columnSuggestStates.isEmpty ? 0 : 1)
                 .blur(radius: needColumnWideBlur ? 0.75 : 0)
             }
-            .frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight)
+            .frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight(screenWidth: variableStates.screenWidth))
         }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/EmojiTabResultBar.swift
@@ -17,10 +17,18 @@ struct EmojiTabResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: V
     @EnvironmentObject private var variableStates: VariableStates
     @Namespace private var namespace
     private var buttonHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.9
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.9
     }
     private var searchBarHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.8
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.8
     }
     private var searchBarDesign: InKeyboardSearchBar<Extension>.Configuration {
         .init(placeholder: "絵文字を検索", theme: theme)

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
@@ -103,11 +103,19 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
     }
 
     private var circleSize: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.8
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.8
     }
 
     private var iconSize: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.6
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.6
     }
 
     var body: some View {

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
@@ -162,7 +162,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                     // offsetを計算する
                     // タップした位置を理解する
                     // 左端がx=0の座標系で考える。
-                    let center_x = variableStates.interfacePosition.x + SemiStaticStates.shared.screenWidth / 2
+                    let center_x = variableStates.interfacePosition.x + variableStates.screenWidth / 2
                     let x = value.startLocation.x
                     // あpい|う え
                     // pの位置をタップした場合、このdiffは-1*itemWidthに近い値になる

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
@@ -34,10 +34,18 @@ struct ResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     }
 
     private var buttonWidth: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.5
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.5
     }
     private var buttonHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.6
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.6
     }
 
     init(isResultViewExpanded: Binding<Bool>) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/TabBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/TabBar.swift
@@ -39,10 +39,24 @@ struct TabBarView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                                 Image(systemName: image)
                             }
                         }
-                        .buttonStyle(ResultButtonStyle<Extension>(height: Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.6))
+                        .buttonStyle(
+                            ResultButtonStyle<Extension>(
+                                height: Design.keyboardBarHeight(
+                                    interfaceHeight: variableStates.interfaceSize.height,
+                                    orientation: variableStates.keyboardOrientation,
+                                    screenWidth: variableStates.screenWidth
+                                ) * 0.6
+                            )
+                        )
                     }
                 }
             }
-        }.frame(height: Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation))
+        }.frame(
+            height: Design.keyboardBarHeight(
+                interfaceHeight: variableStates.interfaceSize.height,
+                orientation: variableStates.keyboardOrientation,
+                screenWidth: variableStates.screenWidth
+            )
+        )
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -34,7 +34,14 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
                             image
                                 .resizable()
                                 .scaledToFill()
-                                .frame(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation))
+                                .frame(
+                                    width: variableStates.screenWidth,
+                                    height: Design.keyboardScreenHeight(
+                                        upsideComponent: variableStates.upsideComponent,
+                                        orientation: variableStates.keyboardOrientation,
+                                        screenWidth: variableStates.screenWidth
+                                    )
+                                )
                                 .clipped()
                         }
                     }
@@ -47,14 +54,26 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
                             UpsideSearchView<Extension>(target: target)
                         }
                     }
-                    .frame(height: Design.upsideComponentHeight(upsideComponent, orientation: variableStates.keyboardOrientation))
+                    .frame(
+                        height: Design.upsideComponentHeight(
+                            upsideComponent,
+                            orientation: variableStates.keyboardOrientation,
+                            screenWidth: variableStates.screenWidth
+                        )
+                    )
                 }
                 if isResultViewExpanded {
                     ExpandedResultView<Extension>(isResultViewExpanded: $isResultViewExpanded)
                 } else {
                     VStack(spacing: 0) {
                         KeyboardBarView<Extension>(isResultViewExpanded: $isResultViewExpanded)
-                            .frame(height: Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation))
+                            .frame(
+                                height: Design.keyboardBarHeight(
+                                    interfaceHeight: variableStates.interfaceSize.height,
+                                    orientation: variableStates.keyboardOrientation,
+                                    screenWidth: variableStates.screenWidth
+                                )
+                            )
                             .padding(.vertical, 6)
                         keyboardView(tab: defaultTab ?? variableStates.tabManager.existentialTab())
                     }
@@ -63,7 +82,7 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
             .resizingFrame(
                 size: $variableStates.interfaceSize,
                 position: $variableStates.interfacePosition,
-                initialSize: CGSize(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, orientation: variableStates.keyboardOrientation)),
+                initialSize: CGSize(width: variableStates.screenWidth, height: Design.keyboardHeight(screenWidth: variableStates.screenWidth, orientation: variableStates.keyboardOrientation)),
                 extension: Extension.self
             )
             .padding(.bottom, 2)
@@ -85,7 +104,13 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
                 TemporalMessageView(message: message, isPresented: isPresented)
             }
         }
-        .frame(height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation))
+        .frame(
+            height: Design.keyboardScreenHeight(
+                upsideComponent: variableStates.upsideComponent,
+                orientation: variableStates.keyboardOrientation,
+                screenWidth: variableStates.screenWidth
+            )
+        )
     }
 
     @MainActor @ViewBuilder

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModelProtocol.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModelProtocol.swift
@@ -32,12 +32,12 @@ enum QwertyKeySizeType: Sendable {
         }
     }
 
-    @MainActor func height(design: TabDependentDesign) -> CGFloat {
+    @MainActor func height(design: TabDependentDesign, screenWidth: CGFloat) -> CGFloat {
         switch self {
         case let .unit(_, height: height):
-            return design.keyViewHeight(heightCount: height)
+            return design.keyViewHeight(heightCount: height, screenWidth: screenWidth)
         default:
-            return design.keyViewHeight
+            return design.keyViewHeight(screenWidth: screenWidth)
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -257,7 +257,8 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             borderColor: keyBorderColor,
                             borderWidth: keyBorderWidth,
                             direction: model.variationsModel.direction,
-                            tabDesign: tabDesign
+                            tabDesign: tabDesign,
+                            screenWidth: variableStates.screenWidth
                         )
                         .overlay(
                             QwertyVariationsView<Extension>(model: self.model.variationsModel, selection: selection, tabDesign: tabDesign)
@@ -274,7 +275,8 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             color: suggestColor,
                             borderColor: keyBorderColor,
                             borderWidth: keyBorderWidth,
-                            tabDesign: tabDesign
+                            tabDesign: tabDesign,
+                            screenWidth: variableStates.screenWidth
                         )
                         .overlay(
                             label(width: size.width, color: suggestTextColor)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySuggestView.swift
@@ -32,7 +32,7 @@ enum VariationsViewDirection {
 }
 
 struct QwertySuggestView {
-    @MainActor static func expandedPath(rdw: CGFloat, ldw: CGFloat, width: CGFloat, tabDesign: TabDependentDesign) -> some Shape {
+    @MainActor static func expandedPath(rdw: CGFloat, ldw: CGFloat, width: CGFloat, tabDesign: TabDependentDesign, screenWidth: CGFloat) -> some Shape {
         Path { path in
             path.move(to: CGPoint(x: 122, y: 281))
             path.addLine(to: CGPoint(x: 53, y: 281))
@@ -85,31 +85,31 @@ struct QwertySuggestView {
             )
         }
         .offsetBy(dx: -175 / 2 + width / 2, dy: 0 )
-        .scale(x: width / 109, y: (tabDesign.keyViewHeight * 2 + tabDesign.verticalSpacing) / 281, anchor: .top)
+        .scale(x: width / 109, y: (tabDesign.keyViewHeight(screenWidth: screenWidth) * 2 + tabDesign.verticalSpacing) / 281, anchor: .top)
     }
 
-    @MainActor static func scaleToFrameSize(keyWidth: CGFloat, scale_y: CGFloat, color: Color, borderColor: Color, borderWidth: CGFloat, tabDesign: TabDependentDesign) -> some View {
-        let height = (tabDesign.keyViewHeight * 2 + tabDesign.verticalSpacing) * scale_y
-        return expandedPath(rdw: 0, ldw: 0, width: keyWidth, tabDesign: tabDesign)
+    @MainActor static func scaleToFrameSize(keyWidth: CGFloat, scale_y: CGFloat, color: Color, borderColor: Color, borderWidth: CGFloat, tabDesign: TabDependentDesign, screenWidth: CGFloat) -> some View {
+        let height = (tabDesign.keyViewHeight(screenWidth: screenWidth) * 2 + tabDesign.verticalSpacing) * scale_y
+        return expandedPath(rdw: 0, ldw: 0, width: keyWidth, tabDesign: tabDesign, screenWidth: screenWidth)
             .strokeAndFill(fillContent: color, strokeContent: borderColor, lineWidth: borderWidth)
             .frame(width: keyWidth, height: height)
     }
 
-    @MainActor static func scaleToVariationsSize(keyWidth: CGFloat, scale_y: CGFloat, variationsCount: Int, color: Color, borderColor: Color, borderWidth: CGFloat, direction: VariationsViewDirection, tabDesign: TabDependentDesign) -> some View {
-        let keyViewSize = tabDesign.keyViewSize
+    @MainActor static func scaleToVariationsSize(keyWidth: CGFloat, scale_y: CGFloat, variationsCount: Int, color: Color, borderColor: Color, borderWidth: CGFloat, direction: VariationsViewDirection, tabDesign: TabDependentDesign, screenWidth: CGFloat) -> some View {
+        let keyViewSize = tabDesign.keyViewSize(screenWidth: screenWidth)
         let height = (keyViewSize.height * 2 + tabDesign.verticalSpacing) * scale_y
         let dw = (keyViewSize.width * CGFloat(variationsCount - 1) + tabDesign.horizontalSpacing * CGFloat(variationsCount - 1)) * 109 / keyViewSize.width
         switch direction {
         case .center:
-            return expandedPath(rdw: dw / 2, ldw: dw / 2, width: keyWidth, tabDesign: tabDesign)
+            return expandedPath(rdw: dw / 2, ldw: dw / 2, width: keyWidth, tabDesign: tabDesign, screenWidth: screenWidth)
                 .strokeAndFill(fillContent: color, strokeContent: borderColor, lineWidth: borderWidth)
                 .frame(width: keyWidth, height: height)
         case .right:
-            return expandedPath(rdw: dw, ldw: 0, width: keyWidth, tabDesign: tabDesign)
+            return expandedPath(rdw: dw, ldw: 0, width: keyWidth, tabDesign: tabDesign, screenWidth: screenWidth)
                 .strokeAndFill(fillContent: color, strokeContent: borderColor, lineWidth: borderWidth)
                 .frame(width: keyWidth, height: height)
         case .left:
-            return expandedPath(rdw: 0, ldw: dw, width: keyWidth, tabDesign: tabDesign)
+            return expandedPath(rdw: 0, ldw: dw, width: keyWidth, tabDesign: tabDesign, screenWidth: screenWidth)
                 .strokeAndFill(fillContent: color, strokeContent: borderColor, lineWidth: borderWidth)
                 .frame(width: keyWidth, height: height)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyVariationsView.swift
@@ -15,6 +15,7 @@ struct QwertyVariationsView<Extension: ApplicationSpecificKeyboardViewExtension>
     @Environment(Extension.Theme.self) private var theme
     @Namespace private var namespace
     private let tabDesign: TabDependentDesign
+    @EnvironmentObject private var variableStates: VariableStates
 
     init(model: VariationsModel, selection: Int?, tabDesign: TabDependentDesign) {
         self.tabDesign = tabDesign
@@ -38,7 +39,7 @@ struct QwertyVariationsView<Extension: ApplicationSpecificKeyboardViewExtension>
                     }
                     getLabel(model.variations[index].label, textColor: index == selection ? .white : theme.suggestLabelTextColor?.color ?? .black)
                 }
-                .frame(width: tabDesign.keyViewWidth, height: tabDesign.keyViewHeight * 0.9, alignment: .center)
+                .frame(width: tabDesign.keyViewWidth, height: tabDesign.keyViewHeight(screenWidth: variableStates.screenWidth) * 0.9, alignment: .center)
             }
         }
         .animation(.easeOut(duration: 0.075), value: selection)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyKeyboardView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct QwertyKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let tabDesign: TabDependentDesign
     private let keyModels: [[any QwertyKeyModelProtocol<Extension>]]
+    @EnvironmentObject private var variableStates: VariableStates
 
     init(keyModels: [[any QwertyKeyModelProtocol<Extension>]], interfaceSize: CGSize, keyboardOrientation: KeyboardOrientation) {
         self.keyModels = keyModels
@@ -37,7 +38,7 @@ struct QwertyKeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>: 
                             tabDesign: tabDesign,
                             size: CGSize(
                                 width: model.keySizeType.width(design: tabDesign),
-                                height: model.keySizeType.height(design: tabDesign)
+                                height: model.keySizeType.height(design: tabDesign, screenWidth: variableStates.screenWidth)
                             )
                         )
                     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -154,7 +154,12 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 
     /// 参考用
     private var keysHeight: CGFloat {
-        TabDependentDesign(width: 1, height: 1, interfaceSize: variableStates.interfaceSize, orientation: variableStates.keyboardOrientation).keysHeight
+        TabDependentDesign(
+            width: 1,
+            height: 1,
+            interfaceSize: variableStates.interfaceSize,
+            orientation: variableStates.keyboardOrientation
+        ).keysHeight(screenWidth: variableStates.screenWidth)
     }
 
     private var scrollViewHeight: CGFloat {

--- a/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
@@ -17,10 +17,18 @@ struct UpsideSearchView<Extension: ApplicationSpecificKeyboardViewExtension>: Vi
     @State private var searchQuery = ""
     private let target: [ConverterBehaviorSemantics.ReplacementTarget]
     private var buttonHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.9
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.9
     }
     private var searchBarHeight: CGFloat {
-        Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation) * 0.8
+        Design.keyboardBarHeight(
+            interfaceHeight: variableStates.interfaceSize.height,
+            orientation: variableStates.keyboardOrientation,
+            screenWidth: variableStates.screenWidth
+        ) * 0.8
     }
 
     init(target: [ConverterBehaviorSemantics.ReplacementTarget]) {

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -215,19 +215,9 @@ import SwiftUtils
             variableStates.setTab(type)
 
         case let .setUpsideComponent(type):
-            switch type {
-            case nil:
-                if variableStates.upsideComponent != nil {
-                    variableStates.upsideComponent = nil
-                    self.delegate.reloadAllView()
-                } else {
-                    variableStates.upsideComponent = nil
-                }
-            case .some:
+            if variableStates.upsideComponent != type {
                 variableStates.upsideComponent = type
-                self.delegate.reloadAllView()
             }
-
         case let .setTabBar(operation):
             switch operation {
             case .on:

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -243,7 +243,7 @@ import SwiftUtils
             }
 
         case .enableResizingMode:
-            variableStates.setResizingMode(.resizing)
+            variableStates.setResizingMode(.resizing, screenWidth: variableStates.screenWidth)
 
         case .hideLearningMemory:
             self.hideLearningMemory()

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -81,8 +81,8 @@ final class KeyboardViewController: UIInputViewController {
         super.viewDidLoad()
         // 初回のみscreenWidthに初期値を与える
         // FIXME: アドホックな対処であり、例えば初期状態でiPhoneを横持ちしている場合には不正な挙動が発生する
-        if SemiStaticStates.shared.screenWidth == 0 {
-            SemiStaticStates.shared.setScreenWidth(UIScreen.main.bounds.width)
+        if Self.variableStates.screenWidth == 0 {
+            Self.variableStates.screenWidth = UIScreen.main.bounds.width
         }
 
         debug("KeyboardViewController.viewDidLoad, loadedInstanceCount:", KeyboardViewController.loadedInstanceCount)
@@ -233,7 +233,7 @@ final class KeyboardViewController: UIInputViewController {
     func registerScreenActualSize() {
         if let bounds = KeyboardViewController.keyboardViewHost?.view.safeAreaLayoutGuide.owningView?.bounds {
             debug("KeyboardViewController.registerScreenActualSize bounds", bounds)
-            SemiStaticStates.shared.setScreenWidth(bounds.width)
+            Self.variableStates.screenWidth = bounds.width
             KeyboardViewController.variableStates.setInterfaceSize(orientation: UIScreen.main.bounds.size.width < UIScreen.main.bounds.size.height ? .vertical : .horizontal, screenWidth: bounds.width)
         }
     }
@@ -263,14 +263,14 @@ final class KeyboardViewController: UIInputViewController {
         // この関数は「これから」向きが変わる場合に呼ばれるので、デバイスの向きによってwidthとheightが逆転するUIScreen.main.bounds.sizeを用いて向きを確かめることができる。
         // ただしこの時点でのUIScreen.mainの値はOSバージョンで変わる
         debug("KeyboardViewController.viewWillTransition", size, UIScreen.main.bounds.size)
-        SemiStaticStates.shared.setScreenWidth(size.width)
+        Self.variableStates.screenWidth = size.width
         KeyboardViewController.variableStates.setInterfaceSize(orientation: UIScreen.main.bounds.width < UIScreen.main.bounds.height ? .horizontal : .vertical, screenWidth: size.width)
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        debug("KeyboardViewController.viewDidLayoutSubviews", SemiStaticStates.shared.screenWidth)
-        self.view.frame.size.height = Design.keyboardScreenHeight(upsideComponent: KeyboardViewController.variableStates.upsideComponent, orientation: KeyboardViewController.variableStates.keyboardOrientation)
+        debug("KeyboardViewController.viewDidLayoutSubviews", Self.variableStates.screenWidth)
+        self.view.frame.size.height = Design.keyboardScreenHeight(upsideComponent: KeyboardViewController.variableStates.upsideComponent, orientation: KeyboardViewController.variableStates.keyboardOrientation, screenWidth: Self.variableStates.screenWidth)
     }
 
     func reloadAllView() {

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -102,7 +102,7 @@ final class KeyboardViewController: UIInputViewController {
                     screenWidth: proxy.size.width,
                     orientation: variableStates.keyboardOrientation,
                     upsideComponent: variableStates.upsideComponent
-                )
+                ) + 2
                 KeyboardView<AzooKeyKeyboardViewExtension>()
                     .onAppear {
                         variableStates.screenWidth = proxy.size.width

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -15,6 +15,13 @@ import SwiftUtils
 import UIKit
 
 final private class KeyboardHostingController<Content: View>: UIHostingController<Content> {
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if #unavailable(iOS 16) {
+            self.view.invalidateIntrinsicContentSize()
+        }
+    }
+
     override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
         .bottom
     }
@@ -126,7 +133,9 @@ final class KeyboardViewController: UIInputViewController {
     private func setupKeyboardView() {
         let host = KeyboardViewController.keyboardViewHost ?? KeyboardHostingController(rootView: Keyboard(theme: getCurrentTheme()))
         // コンテントのサイズに応じてkeyboardViewHostのサイズが可変になる
-        host.sizingOptions = [.intrinsicContentSize]
+        if #available(iOS 16, *) {
+            host.sizingOptions = [.intrinsicContentSize]
+        }
         // コントロールセンターを出しにくくする。
         host.setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
 

--- a/MainApp/Customize/CustardInformationView.swift
+++ b/MainApp/Customize/CustardInformationView.swift
@@ -87,7 +87,7 @@ struct CustardInformationView: View {
         Form {
             let custard = custard
             CenterAlignedView {
-                KeyboardPreview(scale: 0.7, defaultTab: .custard(custard))
+                KeyboardPreview(defaultTab: .custard(custard))
             }
             HStack {
                 Text("タブ名")

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -310,7 +310,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
             }
         }
         .onAppear {
-            variableStates.setInterfaceSize(orientation: MainAppDesign.keyboardOrientation, screenWidth: SemiStaticStates.shared.screenWidth)
+            variableStates.setInterfaceSize(orientation: MainAppDesign.keyboardOrientation, screenWidth: variableStates.screenWidth)
         }
     }
 

--- a/MainApp/Customize/ManageCustardView.swift
+++ b/MainApp/Customize/ManageCustardView.swift
@@ -198,7 +198,7 @@ struct ManageCustardView: View {
                     Section(header: Text("読み込んだタブ")) {
                         Text("「\(custard.metadata.display_name)(\(custard.identifier))」の読み込みに成功しました")
                         CenterAlignedView {
-                            KeyboardPreview(scale: 0.7, defaultTab: .custard(custard))
+                            KeyboardPreview(defaultTab: .custard(custard))
                         }
                         Toggle("タブバーに追加", isOn: $addTabBar)
                         Button("保存") {
@@ -387,7 +387,7 @@ struct URLImportCustardView: View {
                     Section(header: Text("読み込んだタブ")) {
                         Text("「\(custard.metadata.display_name)(\(custard.identifier))」の読み込みに成功しました")
                         CenterAlignedView {
-                            KeyboardPreview(scale: 0.7, defaultTab: .custard(custard))
+                            KeyboardPreview(defaultTab: .custard(custard))
                         }
                         Toggle("タブバーに追加", isOn: $addTabBar)
                         Button("保存") {

--- a/MainApp/General/KeyboardPreview.swift
+++ b/MainApp/General/KeyboardPreview.swift
@@ -20,40 +20,94 @@ private struct CandidateMock: ResultViewItemData {
     }
     #endif
 }
+private struct HeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
 
 @MainActor
 struct KeyboardPreview: View {
     private let theme: AzooKeyTheme
-
-    private let scale: CGFloat
+    @State private var height: CGFloat = 100
     private let defaultTab: Tab.ExistentialTab?
     @StateObject private var variableStates = VariableStates(
-        interfaceWidth: UIScreen.main.bounds.width,
         orientation: MainAppDesign.keyboardOrientation,
         clipboardHistoryManagerConfig: ClipboardHistoryManagerConfig(),
         tabManagerConfig: TabManagerConfig(),
         userDefaults: UserDefaults.standard
     )
 
-    init(theme: AzooKeyTheme? = nil, scale: CGFloat = 1, defaultTab: Tab.ExistentialTab? = nil) {
+    init(theme: AzooKeyTheme? = nil, defaultTab: Tab.ExistentialTab? = nil) {
         self.theme = theme ?? AzooKeySpecificTheme.default(layout: defaultTab?.layout ?? .flick)
-        self.scale = scale
         self.defaultTab = defaultTab
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            let keyboardWidth = proxy.size.width
+            let keyboardHeight = Design.keyboardScreenHeight(upsideComponent: nil, orientation: MainAppDesign.keyboardOrientation, screenWidth: proxy.size.width)
+            KeyboardView<AzooKeyKeyboardViewExtension>(defaultTab: defaultTab)
+                .environmentObject(variableStates)
+                .themeEnvironment(theme)
+                .environment(\.showMessage, false)
+                .frame(width: keyboardWidth, height: keyboardHeight)
+                .onAppear {
+                    variableStates.resultModel.setResults([
+                        CandidateMock(text: "azooKey"),
+                        CandidateMock(text: "あずーきー"),
+                        CandidateMock(text: "アズーキー")
+                    ])
+                    variableStates.screenWidth = keyboardWidth
+                    variableStates.setInterfaceSize(orientation: MainAppDesign.keyboardOrientation, screenWidth: keyboardWidth)
+                }
+                .onChange(of: keyboardWidth) { newValue in
+                    variableStates.screenWidth = newValue
+                    variableStates.setInterfaceSize(orientation: MainAppDesign.keyboardOrientation, screenWidth: newValue)
+                }
+                .preference(key: HeightKey.self, value: keyboardHeight)
+        }
+        .onPreferenceChange(HeightKey.self) {
+            self.height = $0
+        }
+        .frame(height: self.height)
+    }
+}
+
+/// GeometryReaderが不要な場合にのみ利用を推奨
+@MainActor
+struct RawKeyboardPreview: View {
+    private let theme: AzooKeyTheme
+    private let defaultTab: Tab.ExistentialTab?
+    @StateObject private var variableStates = VariableStates(
+        orientation: MainAppDesign.keyboardOrientation,
+        clipboardHistoryManagerConfig: ClipboardHistoryManagerConfig(),
+        tabManagerConfig: TabManagerConfig(),
+        userDefaults: UserDefaults.standard
+    )
+
+    init(theme: AzooKeyTheme? = nil, defaultTab: Tab.ExistentialTab? = nil) {
+        self.theme = theme ?? AzooKeySpecificTheme.default(layout: defaultTab?.layout ?? .flick)
+        self.defaultTab = defaultTab
+    }
+
+    var body: some View {
+        let keyboardWidth = UIScreen.main.bounds.width
+        let keyboardHeight = Design.keyboardScreenHeight(upsideComponent: nil, orientation: MainAppDesign.keyboardOrientation, screenWidth: UIScreen.main.bounds.width)
         KeyboardView<AzooKeyKeyboardViewExtension>(defaultTab: defaultTab)
             .environmentObject(variableStates)
             .themeEnvironment(theme)
             .environment(\.showMessage, false)
-            .scaleEffect(scale)
-            .frame(width: SemiStaticStates.shared.screenWidth * scale, height: Design.keyboardScreenHeight(upsideComponent: nil, orientation: MainAppDesign.keyboardOrientation) * scale)
+            .frame(width: keyboardWidth, height: keyboardHeight)
             .onAppear {
                 variableStates.resultModel.setResults([
                     CandidateMock(text: "azooKey"),
                     CandidateMock(text: "あずーきー"),
                     CandidateMock(text: "アズーキー")
                 ])
+                variableStates.screenWidth = keyboardWidth
+                variableStates.setInterfaceSize(orientation: MainAppDesign.keyboardOrientation, screenWidth: keyboardWidth)
             }
     }
 }

--- a/MainApp/MainApp.swift
+++ b/MainApp/MainApp.swift
@@ -30,7 +30,6 @@ final class MainAppStates: ObservableObject {
         self.englishLayout = englishKeyboardLayout
         self.custardManager = CustardManager.load()
         SemiStaticStates.shared.setHapticsAvailable()
-        SemiStaticStates.shared.setScreenWidth(UIScreen.main.bounds.width)
     }
 
     func setTutorialProgress(_ progress: EnableAzooKeyViewProgress) {

--- a/MainApp/Setting/KeyboardLayout/KeyboardLayoutSettingItemView.swift
+++ b/MainApp/Setting/KeyboardLayout/KeyboardLayoutSettingItemView.swift
@@ -103,7 +103,7 @@ struct LanguageLayoutSettingView<SettingKey: LanguageLayoutKeyboardSetting>: Vie
                     }
                 }
                 CenterAlignedView {
-                    KeyboardPreview(scale: 0.8, defaultTab: tab)
+                    KeyboardPreview(defaultTab: tab)
                         .allowsHitTesting(false)
                         .disabled(true)
                 }
@@ -111,7 +111,7 @@ struct LanguageLayoutSettingView<SettingKey: LanguageLayoutKeyboardSetting>: Vie
                 VStack {
                     Text(labelText)
                     CenterAlignedView {
-                        KeyboardPreview(scale: 0.8, defaultTab: tab)
+                        KeyboardPreview(defaultTab: tab)
                             .allowsHitTesting(false)
                             .disabled(true)
                     }

--- a/MainApp/Theme/ThemeEditView.swift
+++ b/MainApp/Theme/ThemeEditView.swift
@@ -200,9 +200,17 @@ struct ThemeEditView: CancelableEditor {
                             uiImage: pickedImage,
                             resultImage: $trimmedImage,
                             maxSize: CGSize(width: 1280, height: 720),
-                            aspectRatio: CGSize(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardScreenHeight(upsideComponent: nil, orientation: MainAppDesign.keyboardOrientation))
+                            aspectRatio: CGSize(
+                                width: UIScreen.main.bounds.width,
+                                height: Design.keyboardScreenHeight(
+                                    upsideComponent: nil,
+                                    orientation: MainAppDesign.keyboardOrientation,
+                                    screenWidth: UIScreen.main.bounds.width
+                                )
+                            )
                         )}
-                }, isActive: $isTrimmingViewPresented) {
+                },
+                               isActive: $isTrimmingViewPresented) {
                     EmptyView()
                 }
             }

--- a/MainApp/Theme/ThemeShareView.swift
+++ b/MainApp/Theme/ThemeShareView.swift
@@ -30,12 +30,11 @@ struct ThemeShareView: View {
         self.shareImage = shareImage
     }
     @State private var showActivityView: Bool = false
-    // キャプチャ用
-    @State private var captureRect: CGRect = .zero
     private var shareImage: ShareImage
 
     @MainActor @ViewBuilder private var keyboardPreview: some View {
-        KeyboardPreview(theme: theme, scale: 0.9)
+        RawKeyboardPreview(theme: theme)
+            .frame(maxWidth: .infinity)
     }
     var body: some View {
         VStack {

--- a/MainApp/Theme/ThemeTab.swift
+++ b/MainApp/Theme/ThemeTab.swift
@@ -60,7 +60,7 @@ struct ThemeTabView: View {
             if let theme = theme(at: index) {
                 HStack {
                     ZStack {
-                        KeyboardPreview(theme: theme, scale: 0.6, defaultTab: tab)
+                        KeyboardPreview(theme: theme, defaultTab: tab)
                             .disabled(true)
                             .overlay {
                                 if manager.selectedIndex == index || manager.selectedIndexInDarkMode == index {
@@ -113,6 +113,7 @@ struct ThemeTabView: View {
                     }
                     .labelStyle(.iconOnly)
                     .buttonStyle(LargeButtonStyle(backgroundColor: .systemGray5))
+                    .frame(maxWidth: 100)
                     Spacer()
                     // 編集用
                     if editViewIndex == index {


### PR DESCRIPTION
* 現在の実装はscreenWidthを固定と想定しているため、動的な変更ができない
* iPadOSのSplit Viewなどで問題になっていた
* screenWidthをvariableStateに移動することでこの問題を解決する
* また、GeometryReaderとPreferenceで幅の取得を行うことで、回転やUpsideComponentの追加の実装が簡素になった
* [ ] 着せ替えのシェアのスクショが壊れている問題を修正する
* [ ] 初回起動時の描画がうまくいかない問題を修正する
* [ ] 着せ替えの一覧画面の更新