### PR TITLE
Add cache action for Swift build artifacts

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,11 +18,14 @@ jobs:
     - uses: swift-actions/setup-swift@cdbe0f7f4c77929b6580e71983e8606e55ffe7e4
       with:
         swift-version: "5.9"
+
     - uses: actions/checkout@v4
       with:
         submodules: true
+
     - name: Build
       # TODO: add KeyboardViews
       run: swift build --package-path AzooKeyCore --target SwiftUIUtils;swift build --package-path AzooKeyCore --target KeyboardThemes
+
     - name: Run tests
       run: echo "There is no test suits yet"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,6 +23,15 @@ jobs:
       with:
         submodules: true
 
+    - uses: actions/cache@v4
+      with:
+        path: |
+          .build
+          ~/Library/Caches/org.swift.swiftpm
+        key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-swift-
+
     - name: Build
       # TODO: add KeyboardViews
       run: swift build --package-path AzooKeyCore --target SwiftUIUtils;swift build --package-path AzooKeyCore --target KeyboardThemes

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
         path: |
           .build
           ~/Library/Caches/org.swift.swiftpm
-        key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+        key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.swift') }}
         restore-keys: |
           ${{ runner.os }}-swift-
 


### PR DESCRIPTION
This pull request adds a cache action to the GitHub workflow in order to cache the Swift build artifacts. This will improve the build time and reduce the need for rebuilding the dependencies.