### PR TITLE
[Feature] 改善されたスクロール式カスタムタブの編集UIを実装

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
@@ -59,12 +59,12 @@ public extension UserMadeCustard {
 }
 
 public struct UserMadeGridScrollCustard: Codable, Sendable {
-    public init(tabName: String, direction: CustardInterfaceLayoutScrollValue.ScrollDirection, columnCount: String, rowCount: String, words: String, addTabBarAutomatically: Bool) {
+    public init(tabName: String, direction: CustardInterfaceLayoutScrollValue.ScrollDirection, columnCount: String, rowCount: String, keys: [UserMadeKeyData], addTabBarAutomatically: Bool) {
         self.tabName = tabName
         self.direction = direction
         self.columnCount = columnCount
         self.rowCount = rowCount
-        self.words = words
+        self.keys = keys
         self.addTabBarAutomatically = addTabBarAutomatically
     }
 
@@ -72,12 +72,83 @@ public struct UserMadeGridScrollCustard: Codable, Sendable {
     public var direction: CustardInterfaceLayoutScrollValue.ScrollDirection
     public var columnCount: String
     public var rowCount: String
-    public var words: String
+    public var keys: [UserMadeKeyData]
     public var addTabBarAutomatically: Bool
+
+    enum CodingKeys: CodingKey {
+        case tabName
+        case direction
+        case columnCount
+        case rowCount
+        case addTabBarAutomatically
+        case keys
+        /// for interop
+        /// until Version 2.2.3
+        /// String-like "é\n√\nπ\nΩ"
+        @available(*, deprecated, renamed: "keys")
+        case words
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container: KeyedDecodingContainer<UserMadeGridScrollCustard.CodingKeys> = try decoder.container(keyedBy: UserMadeGridScrollCustard.CodingKeys.self)
+
+        self.tabName = try container.decode(String.self, forKey: UserMadeGridScrollCustard.CodingKeys.tabName)
+        self.direction = try container.decode(CustardInterfaceLayoutScrollValue.ScrollDirection.self, forKey: UserMadeGridScrollCustard.CodingKeys.direction)
+        self.columnCount = try container.decode(String.self, forKey: UserMadeGridScrollCustard.CodingKeys.columnCount)
+        self.rowCount = try container.decode(String.self, forKey: UserMadeGridScrollCustard.CodingKeys.rowCount)
+        if container.contains(.keys) {
+            self.keys = try container.decode([UserMadeKeyData].self, forKey: UserMadeGridScrollCustard.CodingKeys.keys)
+        } else {
+            let words = try container.decode(String.self, forKey: UserMadeGridScrollCustard.CodingKeys.words)
+            self.keys = Self.wordsToKeys(words)
+        }
+        self.addTabBarAutomatically = try container.decode(Bool.self, forKey: UserMadeGridScrollCustard.CodingKeys.addTabBarAutomatically)
+
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container: KeyedEncodingContainer<UserMadeGridScrollCustard.CodingKeys> = encoder.container(keyedBy: UserMadeGridScrollCustard.CodingKeys.self)
+        try container.encode(self.tabName, forKey: UserMadeGridScrollCustard.CodingKeys.tabName)
+        try container.encode(self.direction, forKey: UserMadeGridScrollCustard.CodingKeys.direction)
+        try container.encode(self.columnCount, forKey: UserMadeGridScrollCustard.CodingKeys.columnCount)
+        try container.encode(self.rowCount, forKey: UserMadeGridScrollCustard.CodingKeys.rowCount)
+        try container.encode(self.keys, forKey: UserMadeGridScrollCustard.CodingKeys.keys)
+        try container.encode(self.addTabBarAutomatically, forKey: UserMadeGridScrollCustard.CodingKeys.addTabBarAutomatically)
+    }
+
+    public static func wordsToKeys(_ words: consuming String) -> [UserMadeKeyData] {
+        var keys: [UserMadeKeyData] = [
+            .init(model: .system(.changeKeyboard), width: 1, height: 1),
+            .init(model: .custom(.init(design: .init(label: .systemImage("list.bullet"), color: .special), press_actions: [.toggleTabBar], longpress_actions: .none, variations: [])), width: 1, height: 1),
+            .init(model: .custom(.init(design: .init(label: .systemImage("delete.left"), color: .special), press_actions: [.delete(1)], longpress_actions: .init(repeat: [.delete(1)]), variations: [])), width: 1, height: 1),
+            .init(model: .system(.enter), width: 1, height: 1)
+        ]
+        for substring in words.split(separator: "\n") {
+            let target = substring.components(separatedBy: "\\|").map {$0.components(separatedBy: "|")}.reduce(into: [String]()) {array, value in
+                if let last = array.last, let first = value.first {
+                    array.removeLast()
+                    array.append([last, first].joined(separator: "|"))
+                    array.append(contentsOf: value.dropFirst())
+                } else {
+                    array.append(contentsOf: value)
+                }
+            }
+            guard let input = target.first else {
+                continue
+            }
+            let label = target.count > 1 ? target[1] : input
+            keys.append(.init(
+                model: .custom(.init(design: .init(label: .text(label), color: .normal), press_actions: [.input(input)], longpress_actions: .none, variations: [])),
+                width: 1,
+                height: 1
+            ))
+        }
+        return keys
+    }
 }
 
 public struct UserMadeTenKeyCustard: Codable, Sendable {
-    public init(tabName: String, rowCount: String, columnCount: String, inputStyle: CustardInputStyle, language: CustardLanguage, keys: [KeyPosition: UserMadeTenKeyCustard.KeyData], emptyKeys: Set<KeyPosition> = [], addTabBarAutomatically: Bool) {
+    public init(tabName: String, rowCount: String, columnCount: String, inputStyle: CustardInputStyle, language: CustardLanguage, keys: [KeyPosition: UserMadeKeyData], emptyKeys: Set<KeyPosition> = [], addTabBarAutomatically: Bool) {
         self.tabName = tabName
         self.rowCount = rowCount
         self.columnCount = columnCount
@@ -93,56 +164,58 @@ public struct UserMadeTenKeyCustard: Codable, Sendable {
     public var columnCount: String
     public var inputStyle: CustardInputStyle
     public var language: CustardLanguage
-    public var keys: [KeyPosition: KeyData]
+    public var keys: [KeyPosition: UserMadeKeyData]
     public var emptyKeys: Set<KeyPosition> = []
     public var addTabBarAutomatically: Bool
+}
 
-    public struct KeyData: Codable, Hashable, Sendable {
-        public init(model: CustardInterfaceKey, width: Int, height: Int) {
-            self.model = model
-            self.width = width
-            self.height = height
+public struct UserMadeKeyData: Codable, Hashable, Sendable, Identifiable {
+    /// - warning: Do not assume `id` is held between execution; this value is re-generated for each `init`
+    public let id = UUID()
+    public init(model: CustardInterfaceKey, width: Int, height: Int) {
+        self.model = model
+        self.width = width
+        self.height = height
+    }
+
+    private enum CodingKeys: CodingKey {
+        case type, key, width, height
+    }
+
+    private enum ModelType: String, Codable {
+        case system, custom
+    }
+
+    public var model: CustardInterfaceKey
+    public var width: Int
+    public var height: Int
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(width, forKey: .width)
+        try container.encode(height, forKey: .height)
+        switch self.model {
+        case let .system(value):
+            try container.encode(ModelType.system, forKey: .type)
+            try container.encode(value, forKey: .key)
+        case let .custom(value):
+            try container.encode(ModelType.custom, forKey: .type)
+            try container.encode(value, forKey: .key)
         }
+    }
 
-        private enum CodingKeys: CodingKey {
-            case type, key, width, height
-        }
-
-        private enum ModelType: String, Codable {
-            case system, custom
-        }
-
-        public var model: CustardInterfaceKey
-        public var width: Int
-        public var height: Int
-
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(width, forKey: .width)
-            try container.encode(height, forKey: .height)
-            switch self.model {
-            case let .system(value):
-                try container.encode(ModelType.system, forKey: .type)
-                try container.encode(value, forKey: .key)
-            case let .custom(value):
-                try container.encode(ModelType.custom, forKey: .type)
-                try container.encode(value, forKey: .key)
-            }
-        }
-
-        public init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.width = try container.decode(Int.self, forKey: .width)
-            self.height = try container.decode(Int.self, forKey: .height)
-            let type = try container.decode(ModelType.self, forKey: .type)
-            switch type {
-            case .system:
-                let key = try container.decode(CustardInterfaceSystemKey.self, forKey: .key)
-                self.model = .system(key)
-            case .custom:
-                let key = try container.decode(CustardInterfaceCustomKey.self, forKey: .key)
-                self.model = .custom(key)
-            }
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.width = try container.decode(Int.self, forKey: .width)
+        self.height = try container.decode(Int.self, forKey: .height)
+        let type = try container.decode(ModelType.self, forKey: .type)
+        switch type {
+        case .system:
+            let key = try container.decode(CustardInterfaceSystemKey.self, forKey: .key)
+            self.model = .system(key)
+        case .custom:
+            let key = try container.decode(CustardInterfaceCustomKey.self, forKey: .key)
+            self.model = .custom(key)
         }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import SwiftUIUtils
 
 @MainActor
-struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
+public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private let model: any SimpleKeyModelProtocol<Extension>
     @EnvironmentObject private var variableStates: VariableStates
     @Environment(Extension.Theme.self) private var theme
@@ -39,7 +39,7 @@ struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
         model.label(width: keyViewWidth, states: variableStates)
     }
 
-    var body: some View {
+    public var body: some View {
         label(width: keyViewWidth)
             .background(
                 RoundedRectangle(cornerRadius: 6)

--- a/MainApp/Customize/CustardInformationView.swift
+++ b/MainApp/Customize/CustardInformationView.swift
@@ -22,7 +22,7 @@ private extension Custard {
         guard case let .gridFit(layout) = self.interface.keyLayout else {
             return nil
         }
-        var keys: [KeyPosition: UserMadeTenKeyCustard.KeyData] = [:]
+        var keys: [KeyPosition: UserMadeKeyData] = [:]
         // empty keysは「キー情報のない位置」とする
         var emptyKeys = Set<KeyPosition>()
         for (position, key) in self.interface.keys {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -18,7 +18,7 @@ extension CustardInterfaceCustomKey {
     static let empty: Self = .init(design: .init(label: .text(""), color: .normal), press_actions: [], longpress_actions: .none, variations: [])
 }
 
-fileprivate extension Dictionary where Key == KeyPosition, Value == UserMadeTenKeyCustard.KeyData {
+fileprivate extension Dictionary where Key == KeyPosition, Value == UserMadeKeyData {
     subscript(key: Key) -> Value {
         get {
             self[key, default: .init(model: .custom(.empty), width: 1, height: 1)]
@@ -31,8 +31,8 @@ fileprivate extension Dictionary where Key == KeyPosition, Value == UserMadeTenK
 
 @MainActor
 struct EditingTenkeyCustardView: CancelableEditor {
-    private static let emptyKey: UserMadeTenKeyCustard.KeyData = .init(model: .custom(.empty), width: 1, height: 1)
-    private static let emptyKeys: [KeyPosition: UserMadeTenKeyCustard.KeyData] = (0..<5).reduce(into: [:]) {dict, x in
+    private static let emptyKey: UserMadeKeyData = .init(model: .custom(.empty), width: 1, height: 1)
+    private static let emptyKeys: [KeyPosition: UserMadeKeyData] = (0..<5).reduce(into: [:]) {dict, x in
         (0..<4).forEach {y in
             dict[.gridFit(x: x, y: y)] = emptyKey
         }
@@ -46,7 +46,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
     @State private var editingItem: UserMadeTenKeyCustard
     @Binding private var manager: CustardManager
     @State private var showPreview = false
-    @State private var copiedKey: UserMadeTenKeyCustard.KeyData?
+    @State private var copiedKey: UserMadeKeyData?
     private var models: [KeyPosition: (model: any FlickKeyModelProtocol<AzooKeyKeyboardViewExtension>, width: Int, height: Int)] {
         (0..<layout.rowCount).reduce(into: [:]) {dict, x in
             (0..<layout.columnCount).forEach {y in

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -5295,22 +5295,6 @@
         }
       }
     },
-    "一行ずつ登録したい文字や単語を入力してください" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "List up letters and sentences you want to use in this custom tab in line-separated format"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        }
-      }
-    },
     "一覧" : {
       "localizations" : {
         "en" : {
@@ -8568,6 +8552,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
+          }
+        }
+      }
+    },
+    "登録する文字" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Words to append"
           }
         }
       }


### PR DESCRIPTION
Resolve #428 
* スクロール式カスタムタブの編集UIを多機能化
  * Drag&Dropによる並び替えをサポート
  * Context Menu経由の削除をサポート
  * キーの詳細な編集をサポート
* UserMadeScrollCustardのCodableを修正
  * 中身のwordsをkeysに置き換えた
* UserMadeKeyDataにidを追加

![image](https://github.com/ensan-hcl/azooKey/assets/63481257/f3d49367-f54e-4285-ada3-f155697b9c87)
