### PR TITLE
[fix] キーボードバーの判定が広すぎる問題を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -52,12 +52,12 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
                 if isResultViewExpanded {
                     ExpandedResultView<Extension>(isResultViewExpanded: $isResultViewExpanded)
                 } else {
-                    VStack(spacing: 0) {
-                        KeyboardBarView<Extension>(isResultViewExpanded: $isResultViewExpanded)
-                            .frame(height: Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation))
-                            .padding(.vertical, 6)
-                        keyboardView(tab: defaultTab ?? variableStates.tabManager.existentialTab())
-                    }
+                    KeyboardBarView<Extension>(isResultViewExpanded: $isResultViewExpanded)
+                        .frame(height: Design.keyboardBarHeight(interfaceHeight: variableStates.interfaceSize.height, orientation: variableStates.keyboardOrientation))
+                        // バーのタッチ判定領域はpaddingより前まで
+                        .contentShape(Rectangle())
+                        .padding(.vertical, 6)
+                    keyboardView(tab: defaultTab ?? variableStates.tabManager.existentialTab())
                 }
             }
             .resizingFrame(


### PR DESCRIPTION
Discordでの議論とGoogle Form経由の要望に基づいてキーボードバーの挙動を調整してみた
## 背景
（Discordのリンクを閲覧するには[https://discord.gg/dY9gHuyZN5](https://discord.gg/dY9gHuyZN5)からazooKeyのDiscordに参加してください
* https://discord.com/channels/1166734354492440638/1166734421609697342/1226359615705452594
* https://discord.com/channels/1166734354492440638/1205918378355851296/1229354165344669756
* https://discord.com/channels/1166734354492440638/1166734421609697342/1229394785094340609