### PR TITLE
Remove unnecessary build step

### DIFF
--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -21,14 +21,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Build Project
-        run: |
-          xcodebuild build -project azooKey.xcodeproj \
-                     -scheme MainApp \
-                     -sdk iphoneos \
-                     -configuration Release \
-                     CODE_SIGNING_ALLOWED=NO
-
       - name: Archive Project
         run: |                        
           xcodebuild archive -project azooKey.xcodeproj \


### PR DESCRIPTION
This pull request removes the unnecessary build step from the project's workflow. The build step was previously included in the workflow but is no longer needed. This change simplifies the workflow and improves efficiency.