### PR TITLE
Add cache for DerivedData in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -15,6 +15,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-derived-data-
+
       - name: Build Project
         run: |
           xcodebuild build -project azooKey.xcodeproj \

--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('**/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-derived-data-
+
       - name: Archive Project
         run: |                        
           xcodebuild archive -project azooKey.xcodeproj \


### PR DESCRIPTION
This pull request adds a cache for the DerivedData folder in the GitHub Actions workflow. This will improve build times by reusing previously built artifacts.