### PR TITLE
feat: SF Symbolsの選択が簡単になるPickerを追加

### DIFF
--- a/MainApp/Customize/CustardInterfaceKeyEditor.swift
+++ b/MainApp/Customize/CustardInterfaceKeyEditor.swift
@@ -554,16 +554,14 @@ struct CustardInterfaceKeyEditor: View {
                     .textFieldStyle(.roundedBorder)
                     .submitLabel(.done)
                 case .systemImage:
-                    TextField("アイコンの名前", text: Binding(
-                                get: {
-                                    key[.custom][.labelImageName, position]
-                                },
-                                set: {
-                                    key[.custom][.labelImageName, position] = $0
-                                })
+                    SystemIconPicker(icon: Binding(
+                        get: {
+                            key[.custom][.labelImageName, position]
+                        },
+                        set: {
+                            key[.custom][.labelImageName, position] = $0
+                        })
                     )
-                    .textFieldStyle(.roundedBorder)
-                    .submitLabel(.done)
                 case .mainAndSub:
                     TextField("メインのラベル", text: Binding(
                                 get: {

--- a/MainApp/General/Pickers/SystemIconPicker.swift
+++ b/MainApp/General/Pickers/SystemIconPicker.swift
@@ -1,0 +1,90 @@
+//
+//  SystemIconPicker.swift
+//  azooKey
+//
+//  Created by miwa on 2024/10/07.
+//  Copyright © 2024 DevEn3. All rights reserved.
+//
+
+import SwiftUI
+
+struct SystemIconPicker: View {
+    init(
+        icon: Binding<String>,
+        recommendation: [String] = [
+            "doc.on.doc",
+            "doc.on.doc.fill",
+            "doc.on.clipboard",
+            "doc.on.clipboard.fill",
+            "scissors",
+            "delete.left",
+            "delete.left.fill",
+            "delete.right",
+            "delete.right.fill",
+            "heart",
+            "clear",
+            "clear.fill",
+            "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right",
+            "arrowtriangle.left.and.line.vertical.and.arrowtriangle.right.fill",
+            "xmark",
+            "shift",
+            "shift.fill",
+            "capslock",
+            "capslock.fill",
+            "globe",
+            "keyboard.chevron.compact.down",
+            "keyboard.chevron.compact.down.fill",
+            "space",
+            "return",
+            "command",
+        ]
+    ) {
+        self._icon = icon
+        self.recommendation = recommendation
+    }
+
+    private var recommendation: [String]
+
+    @Binding var icon: String
+
+    var body: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(), count: 5)) { // カラム数の指定
+            ForEach(recommendation.indices, id: \.self) { index in
+                Button {
+                    self.icon = self.recommendation[index]
+                } label: {
+                    if self.icon == self.recommendation[index] {
+                        Image(systemName: self.recommendation[index])
+                            .frame(width: 45, height: 45)
+                            .foregroundStyle(.white)
+                            .background(.tint)
+                            .cornerRadius(10)
+                    } else {
+                        Image(systemName: self.recommendation[index])
+                            .frame(width: 45, height: 45)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        HStack {
+            TextField("ID", text: $icon, prompt: Text("SF SymbolsのIDを指定"))
+                .textFieldStyle(.roundedBorder)
+                .monospaced()
+                .keyboardType(.asciiCapable)
+                .submitLabel(.done)
+            Image(systemName: self.icon)
+                .frame(width: 45, height: 45)
+                .foregroundStyle(.white)
+                .background(.tint)
+                .cornerRadius(10)
+        }
+        .padding(.horizontal)
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    @Previewable @State var icon = "star"
+    return SystemIconPicker(icon: $icon)
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1333,6 +1333,16 @@
         }
       }
     },
+    "ID" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID"
+          }
+        }
+      }
+    },
     "iOS15のサポートを終了します" : {
       "localizations" : {
         "en" : {
@@ -1464,6 +1474,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "If you want to use the Shift key on the Qwerty English keyboard, please turn on the following setting."
+          }
+        }
+      }
+    },
+    "SF SymbolsのIDを指定" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specify SF Symbols ID"
           }
         }
       }
@@ -1619,22 +1639,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Google search"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        }
-      }
-    },
-    "アイコンの名前" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name of icon"
           }
         },
         "ja" : {


### PR DESCRIPTION
Keyの編集時、SF SymbolsをいちいちIDで指定するのは面倒すぎるので、よく使われそうなシンボルを中心にPickerを用意した。従来通りのテキストフィールドも維持。
![image](https://github.com/user-attachments/assets/4444ef8a-c049-4ee8-a58b-96df86f6c7fe)
