### PR TITLE
fix: MarkedText利用時の no-op callback で composition を停止する

### DIFF
--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -719,9 +719,10 @@ final class KeyboardActionManager: UserActionManager, @unchecked Sendable {
                 return
             }
 
-            // MarkedTextを有効化している場合、テキストの送信等でここに来ることがある
-            @KeyboardSetting(.liveConversion) var liveConversionEnabled
-            if liveConversionEnabled {
+            // MarkedTextを利用する設定では、ホスト側の送信や確定が起きても UITextDocumentProxy からは before/after の差分が見えず、no-op callback としてここに到達することがある。
+            // このとき composition が残っているなら、外部要因で入力が閉じられたとみなして stopComposition し、内部状態をホスト側に合わせる。
+            @KeyboardSetting(.markedTextSetting) var markedTextSetting
+            if markedTextSetting != .disabled, !self.inputManager.composingText.isEmpty {
                 debug("user operation id: 2.5")
                 self.inputManager.stopComposition()
                 return


### PR DESCRIPTION
## 概要
MarkedText を利用する設定で、ホスト側の送信や確定後に `UITextDocumentProxy` から差分が観測できない no-op callback が来た場合でも、composition を適切に停止するようにします。

## 背景
LINE のテキストフィールドで、ライブ変換 OFF・MarkedText 利用時に `おはよう` を未確定のまま送信すると、テキストフィールドは空になる一方で変換候補だけが残り続けていました。

調査の結果、このケースでは `textWillChange` / `textDidChange` から見える `left/center/right` が常に空で、通常の差分解釈では送信を検知できませんでした。
一方で既存コードには no-op callback を composition 終了として扱う救済分岐がありましたが、コメントの意図に反して `liveConversion` の有無でしか有効化されていませんでした。

## 変更内容
- no-op callback を composition 終了として扱う分岐の条件を `liveConversion` 依存から `MarkedText` 利用設定依存へ変更
- その分岐が composition 中にだけ発火するよう `composingText.isEmpty` を条件に追加
- 分岐の意図が分かるようコメントを補足

## 影響
- LINE のように送信時の差分が `UITextDocumentProxy` に現れないホストでも、MarkedText 利用時に候補が残り続けないようになります
- MarkedText を使っていない設定には影響しません

## 確認
- LINE でライブ変換 OFF・MarkedText 利用時に未確定入力を送信して、候補が消えることを確認
- ライブ変換 ON の既存挙動を維持していることを確認