### PR TITLE
fix: ユーザ辞書の削除が復活する問題を修正

### DIFF
--- a/MainApp/Features/Settings/Dictionary/UserDictionary/AzooKeyUserDictionary.swift
+++ b/MainApp/Features/Settings/Dictionary/UserDictionary/AzooKeyUserDictionary.swift
@@ -97,6 +97,7 @@ private struct UserDictionaryDataListView: View {
                             .contextMenu {
                                 Button(role: .destructive) {
                                     variables.items.removeAll(where: {$0.id == data.id})
+                                    variables.save()
                                 } label: {
                                     Label("削除", systemImage: "trash")
                                 }


### PR DESCRIPTION
## 概要
- コンテキストメニューからユーザ辞書を削除した直後に保存する
- スワイプ削除とコンテキストメニュー削除の動作を統一する

## 原因
コンテキストメニュー側はメモリ上の項目だけを削除し、更新後の辞書を保存していませんでした。そのため、辞書を再読み込みすると削除した項目が復活していました。

## 確認
- `xcodebuild -quiet -project azooKey.xcodeproj -scheme MainApp -sdk iphonesimulator -destination generic/platform=iOS\ Simulator CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`