### PR TITLE
fix: カスタムタブ保存後の戻る履歴を修正

### DIFF
--- a/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
@@ -132,6 +132,17 @@ struct EditingGridFitCustardView: CancelableEditor {
         self.isNewItem = editingItem == nil
     }
 
+    private func finishEditing(identifier: String) {
+        dismiss()
+        guard isNewItem, let onFinishEditing else {
+            return
+        }
+        Task { @MainActor in
+            await Task.yield()
+            onFinishEditing(identifier)
+        }
+    }
+
     private func gridFrame(
         position: KeyPosition,
         data: UserMadeKeyData
@@ -422,11 +433,7 @@ struct EditingGridFitCustardView: CancelableEditor {
                     } else {
                         self.save()
                         let saved = custard
-                        if let onFinishEditing {
-                            onFinishEditing(saved.identifier)
-                        } else {
-                            dismiss()
-                        }
+                        finishEditing(identifier: saved.identifier)
                     }
                 }
             }

--- a/MainApp/Features/Customization/Custard/Editing/EditingScrollCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingScrollCustardView.swift
@@ -66,6 +66,17 @@ struct EditingScrollCustardView: CancelableEditor {
         self.isNewItem = editingItem == nil
     }
 
+    private func finishEditing(identifier: String) {
+        dismiss()
+        guard isNewItem, let onFinishEditing else {
+            return
+        }
+        Task { @MainActor in
+            await Task.yield()
+            onFinishEditing(identifier)
+        }
+    }
+
     private var interfaceSize: CGSize {
         let context = MainAppDesign.keyboardLayoutContext(
             containerWidth: UIScreen.main.bounds.width
@@ -246,11 +257,7 @@ struct EditingScrollCustardView: CancelableEditor {
                     } else {
                         self.save()
                         let saved = makeCustard(data: editingItem)
-                        if let onFinishEditing {
-                            onFinishEditing(saved.identifier)
-                        } else {
-                            dismiss()
-                        }
+                        finishEditing(identifier: saved.identifier)
                     }
                 }
             }


### PR DESCRIPTION
## 概要
- カスタムタブ保存時に、まず編集画面を閉じる
- 既存タブの編集後は、現在の詳細画面へ戻る
- 新規作成時だけ、保存後に作成したタブの詳細画面へ進む

## 原因
保存完了コールバックが新規作成と既存編集を区別せず、詳細画面を履歴へ追加していました。既存タブを編集すると同じ詳細画面が重複し、戻る操作で編集画面や重複した詳細画面が表示されていました。

## 確認
- `xcodebuild -quiet -project azooKey.xcodeproj -scheme MainApp -sdk iphonesimulator -destination generic/platform=iOS\ Simulator CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`