### PR TITLE
fix: 通常押しと長押しの境界で入力が抜ける問題を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedGenericKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedGenericKeyView.swift
@@ -198,6 +198,32 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
         }
     }
 
+    private func reserveFlickLongPress(for direction: FlickDirection) {
+        guard let variation = variation(for: direction) else {
+            return
+        }
+        let duration = longpressDuration(variation.longPressActions)
+        action.reserveLongPressAction(
+            variation.longPressActions,
+            taskStartDuration: duration,
+            variableStates: variableStates
+        )
+        lifecycle.longPressTask?.cancel()
+        lifecycle.longPressTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard case let .flickOneSuggested(currentDirection, _) = lifecycle.state,
+                  currentDirection == direction else {
+                return
+            }
+            lifecycle.longPressTask = nil
+            lifecycle.state = .longFlicked(direction)
+        }
+    }
+
     // Fixed policy: decide long-press outcome with priority
     private func decideLongPressOutcome() -> PressLifecycle.Outcome? {
         if model.hasLinearVariations(variableStates: variableStates) {
@@ -272,7 +298,7 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                         }
                         self.commitFlickLongPress()
                     }
-                case let .started(date):
+                case .started:
                     if self.model.isFlickAble(to: d, variableStates: variableStates), startLocation.distance(to: value.location) > self.model.flickSensitivity(to: d) {
                         self.lifecycle.longPressTask?.cancel()
                         self.lifecycle.longPressTask = nil
@@ -284,12 +310,7 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                         self.lifecycle.flickSuggestDismissTask?.cancel()
                         self.action.registerLongPressActionEnd(self.model.longPressActions(variableStates: variableStates))
                         self.lifecycle.flickAllSuggestTask?.cancel()
-                        if let v = variation(for: d) {
-                            self.action.reserveLongPressAction(v.longPressActions, taskStartDuration: longpressDuration(v.longPressActions), variableStates: variableStates)
-                        }
-                    }
-                    if Date().timeIntervalSince(date) >= self.longpressDuration {
-                        self.commitFlickLongPress()
+                        reserveFlickLongPress(for: d)
                     }
                 case let .flickOneSuggested(prevDirection, _):
                     if self.model.isFlickAble(to: d, variableStates: variableStates) {
@@ -312,9 +333,7 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                                 }
                                 self.lifecycle.state = .flickOneSuggested(d, Date())
                                 // reserve for new direction
-                                if let vNew = variation(for: d) {
-                                    self.action.reserveLongPressAction(vNew.longPressActions, taskStartDuration: longpressDuration(vNew.longPressActions), variableStates: variableStates)
-                                }
+                                reserveFlickLongPress(for: d)
                             }
                         }
                     }
@@ -332,9 +351,7 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                                 self.action.registerLongPressActionEnd(vPrev.longPressActions)
                             }
                             self.lifecycle.state = .flickOneSuggested(d, Date())
-                            if let vNew = variation(for: d) {
-                                self.action.reserveLongPressAction(vNew.longPressActions, taskStartDuration: longpressDuration(vNew.longPressActions), variableStates: variableStates)
-                            }
+                            reserveFlickLongPress(for: d)
                         }
                     }
                 case .longPressed:
@@ -355,9 +372,7 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                             // End long-press reservation now that we moved into a direction
                             self.action.registerLongPressActionEnd(self.model.longPressActions(variableStates: variableStates))
                             self.lifecycle.flickAllSuggestTask?.cancel()
-                            if let v = variation(for: d) {
-                                self.action.reserveLongPressAction(v.longPressActions, taskStartDuration: longpressDuration(v.longPressActions), variableStates: variableStates)
-                            }
+                            reserveFlickLongPress(for: d)
                         }
                     }
                 case .linearVariations:
@@ -374,16 +389,6 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                     self.isSuggesting = false
                 }
                 self.lifecycle.flickSuggestDismissTask = dismiss
-                if case let .started(date) = lifecycle.state {
-                    if Date().timeIntervalSince(date) >= self.longpressDuration {
-                        self.lifecycle.state = .longPressed
-                    }
-                }
-                if case let .flickOneSuggested(direction, date) = lifecycle.state {
-                    if let v = variation(for: direction), Date().timeIntervalSince(date) >= self.longpressDuration(v.longPressActions) {
-                        self.lifecycle.state = .longFlicked(direction)
-                    }
-                }
                 self.lifecycle.longPressTask?.cancel()
                 self.lifecycle.longPressTask = nil
                 self.action.registerLongPressActionEnd(self.model.longPressActions(variableStates: variableStates))
@@ -544,12 +549,12 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                 switch self.lifecycle.state {
                 case .idle:
                     break
-                case let .started(date):
+                case .started:
                     let doublePressActions = self.model.doublePressActions(variableStates: variableStates)
                     if !doublePressActions.isEmpty, lifecycle.doublePress.secondPressCompleted {
                         self.action.registerActions(doublePressActions, variableStates: variableStates)
                         self.lifecycle.doublePress.reset()
-                    } else if endDate.timeIntervalSince(date) < longpressDuration {
+                    } else {
                         self.action.registerActions(self.model.pressActions(variableStates: variableStates), variableStates: variableStates)
                     }
                 case .longPressed:


### PR DESCRIPTION
## 概要
- 指を離した時刻から長押し成立を推測する処理をやめる
- 実際の長押しタスクが完了した時点で押下状態を遷移させる
- 長押しが成立する前に指を離した場合は通常入力を確実に実行する
- フリック先の長押しにも同じ状態管理を適用する

## 原因
通常押しと長押しの境界で、指を離す処理と長押しタスクが競合していました。時刻だけでは長押し扱いになっている一方、長押しアクションはまだ発火していない瞬間があり、通常入力も長押し入力も実行されないことがありました。

## 確認
- `xcodebuild -quiet -project azooKey.xcodeproj -scheme MainApp -sdk iphonesimulator -destination generic/platform=iOS\ Simulator CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`