### PR TITLE
fix: 漢字拡大表示を通常の高さで表示

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/LargeTextView.swift
@@ -50,13 +50,11 @@ struct LargeTextView: View {
                 ) * 0.15
             )
         }
-        .background(Color.background)
         .frame(
-            height: Design.keyboardScreenHeight(
-                context: variableStates.layoutContext,
-                upsideComponent: variableStates.upsideComponent
-            ),
+            maxWidth: .infinity,
+            maxHeight: .infinity,
             alignment: .bottom
         )
+        .background(Color.background)
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -57,7 +57,15 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
     }
 
     private var totalBackgroundHeight: CGFloat {
-        resolvedInterfaceHeight + Design.keyboardScreenBottomPadding + componentOverlayHeight
+        let bodyHeight = if variableStates.boolStates.isTextMagnifying {
+            max(
+                resolvedInterfaceHeight,
+                Design.keyboardHeight(context: variableStates.layoutContext)
+            )
+        } else {
+            resolvedInterfaceHeight
+        }
+        return bodyHeight + Design.keyboardScreenBottomPadding + componentOverlayHeight
     }
 
     @ViewBuilder

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -150,9 +150,15 @@ final class KeyboardViewController: UIInputViewController {
                 KeyboardViewController.variableStates.$maximumHeight,
                 KeyboardViewController.variableStates.$upsideComponent
             )
+            .combineLatest(
+                KeyboardViewController.variableStates.$boolStates
+                    .map { $0["isTextMagnifying"] ?? false }
+                    .removeDuplicates()
+            )
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] interfaceSize, state, maxH, upsideComponent in
+            .sink { [weak self] values, isTextMagnifying in
                 guard let self = self else { return }
+                let (interfaceSize, state, maxH, upsideComponent) = values
                 // In resizing mode use the dynamic maxH; otherwise default to interfaceSize.height
                 // 1. upsideComponentの高さを計算する（存在しない場合は0）
                 let upsideComponentHeight = upsideComponent.map { component in
@@ -162,7 +168,17 @@ final class KeyboardViewController: UIInputViewController {
                     )
                 } ?? 0
 
-                let bodyHeight = (state == .resizing) ? maxH : interfaceSize.height
+                let currentBodyHeight = (state == .resizing) ? maxH : interfaceSize.height
+                let bodyHeight = if isTextMagnifying {
+                    max(
+                        currentBodyHeight,
+                        Design.keyboardHeight(
+                            context: KeyboardViewController.variableStates.layoutContext
+                        )
+                    )
+                } else {
+                    currentBodyHeight
+                }
 
                 // 3. 全体の高さを「本体の高さ + upsideComponentの高さ」として計算する
                 let totalHeight = bodyHeight + upsideComponentHeight + Design.keyboardScreenBottomPadding


### PR DESCRIPTION
## 概要

- 漢字拡大表示中は、縮小設定にかかわらず通常のキーボード高まで表示領域を広げる
- 拡大表示の背景と「閉じる」ボタンを利用可能な領域全体へ配置する
- 拡大表示を閉じた後は、保存済みのキーボード高へ戻す

## 原因

漢字拡大表示自身は通常サイズの高さを要求していましたが、親のSwiftUIビューとキーボード拡張の高さ制約は、片手モードなどで縮小した後の高さを維持していました。そのため、下部の「閉じる」ボタンが表示領域外へ見切れていました。

## 影響

片手モードやキーボード高の縮小設定を使用していても、漢字拡大表示を画面いっぱいに表示し、安全に閉じられるようになります。

## 確認

- `xcodebuild -quiet -project azooKey.xcodeproj -scheme MainApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check origin/main...HEAD`
