### PR TITLE
style: SwiftLintの自動修正を適用

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/SharedStore.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/SharedStore.swift
@@ -41,10 +41,10 @@ public enum SharedStore {
         guard let value = userDefaults.dictionary(
             forKey: resolvedKeyboardSizeKey(orientation: orientation)
         ),
-              let width = value["width"] as? NSNumber,
-              let height = value["height"] as? NSNumber,
-              width.doubleValue > 0,
-              height.doubleValue > 0 else {
+        let width = value["width"] as? NSNumber,
+        let height = value["height"] as? NSNumber,
+        width.doubleValue > 0,
+        height.doubleValue > 0 else {
             return nil
         }
         return CGSize(width: width.doubleValue, height: height.doubleValue)

--- a/AzooKeyCore/Sources/CustardKit/CustardKit.swift
+++ b/AzooKeyCore/Sources/CustardKit/CustardKit.swift
@@ -507,7 +507,7 @@ public extension CustardInterface {
         }
         guard supportsQwertySystemKeys else {
             throw CustardInterfaceValidationError
-                .qwertySystemKeyRequiresPCStyleGridFit
+            .qwertySystemKeyRequiresPCStyleGridFit
         }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/ClipboardHistoryManager.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ClipboardHistoryManager.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2023 ensan. All rights reserved.
 //
 
-import class UIKit.UIPasteboard
 import Foundation
 import SwiftUtils
+import class UIKit.UIPasteboard
 
 struct ClipboardHistoryItem: Equatable, Comparable, Hashable, Codable, Identifiable {
     var content: Content

--- a/AzooKeyCore/Sources/KeyboardViews/Custard/FlickEnglishCustard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Custard/FlickEnglishCustard.swift
@@ -25,26 +25,26 @@ public extension Custard {
                 ),
                 .gridFit(.init(x: 1, y: 1)): .custom(
                     .flickSimpleInputs(center: "G", subs: ["H", "I"], centerLabel: "GHI")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 1, y: 2)): .custom(
                     .flickSimpleInputs(center: "P", subs: ["Q", "R", "S"], centerLabel: "PQRS")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 1, y: 3)): .system(.upperLower),   // a/A (大文字・小文字切替)
 
                 // 3列目
-                    .gridFit(.init(x: 2, y: 0)): .custom(
-                        .flickSimpleInputs(center: "A", subs: ["B", "C"], centerLabel: "ABC")
+                .gridFit(.init(x: 2, y: 0)): .custom(
+                    .flickSimpleInputs(center: "A", subs: ["B", "C"], centerLabel: "ABC")
                         .lowercasedInput()
-                    ),
+                ),
                 .gridFit(.init(x: 2, y: 1)): .custom(
                     .flickSimpleInputs(center: "J", subs: ["K", "L"], centerLabel: "JKL")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 2, y: 2)): .custom(
                     .flickSimpleInputs(center: "T", subs: ["U", "V"], centerLabel: "TUV")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 2, y: 3)): .custom(
                     .flickSimpleInputs(center: "'", subs: ["\"", "(", ")"], centerLabel: "'\"()")
@@ -53,15 +53,15 @@ public extension Custard {
                 // 4列目
                 .gridFit(.init(x: 3, y: 0)): .custom(
                     .flickSimpleInputs(center: "D", subs: ["E", "F"], centerLabel: "DEF")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 3, y: 1)): .custom(
                     .flickSimpleInputs(center: "M", subs: ["N", "O"], centerLabel: "MNO")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 3, y: 2)): .custom(
                     .flickSimpleInputs(center: "W", subs: ["X", "Y", "Z"], centerLabel: "WXYZ")
-                    .lowercasedInput()
+                        .lowercasedInput()
                 ),
                 .gridFit(.init(x: 3, y: 3)): .custom(
                     .flickSimpleInputs(center: ".", subs: [",", "?", "!"], centerLabel: ".,?!")

--- a/AzooKeyCore/Sources/KeyboardViews/Custard/FlickNumberSymbolsCustard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Custard/FlickNumberSymbolsCustard.swift
@@ -22,15 +22,15 @@ public extension Custard {
                 // 2列目
                 .gridFit(.init(x: 1, y: 0)): .custom(
                     .flickSimpleInputs(center: "1", subs: ["☆", "♪", "→"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 1, y: 1)): .custom(
                     .flickSimpleInputs(center: "4", subs: ["○", "＊", "・"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 1, y: 2)): .custom(
                     .flickSimpleInputs(center: "7", subs: ["「", "」", ":"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 1, y: 3)): .custom(
                     .flickSimpleInputs(center: "(", subs: [")", "[", "]"], centerLabel: "()[]")
@@ -39,33 +39,33 @@ public extension Custard {
                 // 3列目
                 .gridFit(.init(x: 2, y: 0)): .custom(
                     .flickSimpleInputs(center: "2", subs: ["¥", "$", "€"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 2, y: 1)): .custom(
                     .flickSimpleInputs(center: "5", subs: ["+", "×", "÷"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 2, y: 2)): .custom(
                     .flickSimpleInputs(center: "8", subs: ["〒", "々", "〆"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 2, y: 3)): .custom(
                     .flickSimpleInputs(center: "0", subs: ["〜", "…"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
 
                 // 4列目
                 .gridFit(.init(x: 3, y: 0)): .custom(
                     .flickSimpleInputs(center: "3", subs: ["%", "°", "#"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 3, y: 1)): .custom(
                     .flickSimpleInputs(center: "6", subs: ["<", "=", ">"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 3, y: 2)): .custom(
                     .flickSimpleInputs(center: "9", subs: ["^", "|", "\\"])
-                    .mainAndSubLabel()
+                        .mainAndSubLabel()
                 ),
                 .gridFit(.init(x: 3, y: 3)): .custom(
                     .flickSimpleInputs(center: ".", subs: [",", "-", "/"], centerLabel: ".,-/")

--- a/AzooKeyCore/Sources/KeyboardViews/SemiStaticStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/SemiStaticStates.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2022 ensan. All rights reserved.
 //
 
+import class CoreHaptics.CHHapticEngine
 import Foundation
 import SwiftUI
-import class CoreHaptics.CHHapticEngine
 
 /// 実行しないと値が確定しないが、実行されれば全く変更されない値。収容アプリでも共有できる形にすること。
 public final class SemiStaticStates: @unchecked Sendable {

--- a/AzooKeyCore/Sources/KeyboardViews/States.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/States.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 ensan. All rights reserved.
 //
 
-import enum UIKit.UIReturnKeyType
 import enum KanaKanjiConverterModule.KeyboardLanguage
+import enum UIKit.UIReturnKeyType
 
 extension KeyboardLanguage {
     var shortSymbol: String {

--- a/AzooKeyCore/Sources/KeyboardViews/States/ReportSuggestion.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/States/ReportSuggestion.swift
@@ -1,6 +1,6 @@
 import Foundation
-import struct KanaKanjiConverterModule.ComposingText
 import enum KanaKanjiConverterModule.ComposingCount
+import struct KanaKanjiConverterModule.ComposingText
 
 public struct CandidateSummary: Equatable {
     public let displayText: String

--- a/AzooKeyCore/Sources/KeyboardViews/TabManager.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/TabManager.swift
@@ -8,9 +8,9 @@
 
 import CustardKit
 import Foundation
-import SwiftUI
 import enum KanaKanjiConverterModule.InputStyle
 import enum KanaKanjiConverterModule.KeyboardLanguage
+import SwiftUI
 
 extension TabData {
     func tab(config: any TabManagerConfiguration) -> KeyboardTab {

--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -8,12 +8,12 @@
 
 import CustardKit
 import Foundation
+import enum KanaKanjiConverterModule.InputStyle
+import enum KanaKanjiConverterModule.KeyboardLanguage
 import SwiftUI
 import SwiftUIUtils
 import SwiftUtils
 import UIKit
-import enum KanaKanjiConverterModule.InputStyle
-import enum KanaKanjiConverterModule.KeyboardLanguage
 
 /// 実行中変更され、かつViewがvariationSpace(variableStates: VariableStates)変更を検知できるべき値。
 public final class VariableStates: ObservableObject {

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyLabel.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
+import struct CustardKit.CustardKeyDirectionalLabel
 import Foundation
 import SwiftUI
-import struct CustardKit.CustardKeyDirectionalLabel
 
 public enum KeyLabelType: Sendable, Equatable {
     case text(String)
@@ -27,7 +27,7 @@ public struct DirectionalKeyLabel: View {
         self.font = font
         self.subFont = subFont
     }
-    
+
     let main: String
     let directions: CustardKeyDirectionalLabel
     let font: Font
@@ -119,7 +119,7 @@ public struct KeyLabel<Extension: ApplicationSpecificKeyboardViewExtension>: Vie
                 directions.top,
                 directions.left,
                 directions.right,
-                directions.bottom
+                directions.bottom,
             ]
             .compactMap { $0 }
             .filter { !$0.isEmpty }

--- a/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UpsideComponents/UpsideSearchView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 ensan. All rights reserved.
 //
 
-import SwiftUI
 import enum KanaKanjiConverterModule.ConverterBehaviorSemantics
+import SwiftUI
 
 @MainActor
 struct UpsideSearchView<Extension: ApplicationSpecificKeyboardViewExtension>: View {

--- a/AzooKeyCore/Sources/SwiftUIUtils/BindingConvert.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/BindingConvert.swift
@@ -28,7 +28,7 @@ public extension Binding where Value: Sendable {
     }
 }
 
-public extension Binding where Value == Optional<String> {
+public extension Binding where Value == String? {
     @MainActor
     func wrapped(default: String = "") -> Binding<String> {
         .init(

--- a/AzooKeyCore/Sources/SwiftUIUtils/EditCancelButton.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/EditCancelButton.swift
@@ -15,12 +15,12 @@ public struct EditConfirmButton: View {
         }
     }
 
-    public init(_ type: ConfirmationType = .save, action: @escaping () -> ()) {
+    public init(_ type: ConfirmationType = .save, action: @escaping () -> Void) {
         self.confirmationType = type
         self.action = action
     }
     private var confirmationType: ConfirmationType
-    private var action: () -> ()
+    private var action: () -> Void
 
     public var body: some View {
         if #available(iOS 26, macOS 26, *) {
@@ -37,13 +37,13 @@ public struct EditConfirmButton: View {
 }
 
 public struct EditCancelButton: View {
-    public init(confirmationRequired: Bool = true, action: (() -> ())? = nil) {
+    public init(confirmationRequired: Bool = true, action: (() -> Void)? = nil) {
         self.confirmationRequired = confirmationRequired
         self.action = action
     }
 
     private let confirmationRequired: Bool
-    private var action: (() -> ())?
+    private var action: (() -> Void)?
 
     @State private var showCancellationAlert: Bool = false
     @Environment(\.dismiss) private var dismiss

--- a/AzooKeyCore/Tests/CustardKitTests/ConstantsTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/ConstantsTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class ConstantsTest: XCTestCase {
     func testCustardVersion() {

--- a/AzooKeyCore/Tests/CustardKitTests/CustardExpressionEvaluatorTests.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardExpressionEvaluatorTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardExpressionEvaluatorTests: XCTestCase {
     func testTokenizer() throws {
@@ -84,7 +84,7 @@ final class CustardExpressionEvaluatorTests: XCTestCase {
     struct EvaluatorContext: CustardExpressionEvaluatorContext {
         var initialValues: [String: ExpressionValue]
         func getValue(for key: String) -> ExpressionValue? {
-            return initialValues[key]
+            initialValues[key]
         }
     }
 

--- a/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceLayoutTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceLayoutTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardInterfaceLayoutTest: XCTestCase {
     func testDecode() {

--- a/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceSystemKeyTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceSystemKeyTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardInterfaceSystemKeyTest: XCTestCase {
     func testDecode() {

--- a/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceVariationKeyTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceVariationKeyTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardInterfaceVariationKeyTest: XCTestCase {
     func testDecode() {
@@ -29,11 +29,11 @@ final class CustardInterfaceVariationKeyTest: XCTestCase {
 
     func testEncode() {
         do {
-            let target = CustardInterfaceVariationKey.init(design: .init(label: .systemImage("que")), press_actions: [.dismissKeyboard, .complete, .replaceDefault(.default)], longpress_actions: .none)
+            let target = CustardInterfaceVariationKey(design: .init(label: .systemImage("que")), press_actions: [.dismissKeyboard, .complete, .replaceDefault(.default)], longpress_actions: .none)
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
         do {
-            let target = CustardInterfaceVariationKey.init(design: .init(label: .text("∫")), press_actions: [.input("√")], longpress_actions: .init(start: [.input("≈")]))
+            let target = CustardInterfaceVariationKey(design: .init(label: .text("∫")), press_actions: [.input("√")], longpress_actions: .init(start: [.input("≈")]))
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
     }

--- a/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceVariationTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceVariationTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardInterfaceVariationTest: XCTestCase {
     func testDecode() {
@@ -40,11 +40,11 @@ final class CustardInterfaceVariationTest: XCTestCase {
 
     func testEncode() {
         do {
-            let target = CustardInterfaceVariation.init(type: .flickVariation(.bottom), key: .init(design: .init(label: .text("facebook")), press_actions: [], longpress_actions: .none))
+            let target = CustardInterfaceVariation(type: .flickVariation(.bottom), key: .init(design: .init(label: .text("facebook")), press_actions: [], longpress_actions: .none))
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
         do {
-            let target = CustardInterfaceVariation.init(type: .longpressVariation, key: .init(design: .init(label: .systemImage("twitter")), press_actions: [], longpress_actions: .none))
+            let target = CustardInterfaceVariation(type: .longpressVariation, key: .init(design: .init(label: .systemImage("twitter")), press_actions: [], longpress_actions: .none))
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
     }

--- a/AzooKeyCore/Tests/CustardKitTests/CustardKeyDesignTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardKeyDesignTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardKeyDesignTest: XCTestCase {
     func testDecode() {
@@ -25,11 +25,11 @@ final class CustardKeyDesignTest: XCTestCase {
 
     func testEncode() {
         do {
-            let target = CustardKeyDesign.init(label: .systemImage("uchuhi"), color: .normal)
+            let target = CustardKeyDesign(label: .systemImage("uchuhi"), color: .normal)
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
         do {
-            let target = CustardKeyDesign.init(label: .text("緑和"), color: .special)
+            let target = CustardKeyDesign(label: .text("緑和"), color: .special)
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
     }

--- a/AzooKeyCore/Tests/CustardKitTests/CustardKeyLabelStyleTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardKeyLabelStyleTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardKeyLabelStyleTest: XCTestCase {
     func testDecode() {

--- a/AzooKeyCore/Tests/CustardKitTests/CustardMetadataTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardMetadataTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardMetadataTest: XCTestCase {
     func testDecode() {
@@ -16,11 +16,11 @@ final class CustardMetadataTest: XCTestCase {
 
     func testEncode() {
         do {
-            let target = CustardMetadata.init(custard_version: .v1_0, display_name: "unknown")
+            let target = CustardMetadata(custard_version: .v1_0, display_name: "unknown")
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
         do {
-            let target = CustardMetadata.init(custard_version: .v1_0, display_name: "unhappy")
+            let target = CustardMetadata(custard_version: .v1_0, display_name: "unhappy")
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
     }

--- a/AzooKeyCore/Tests/CustardKitTests/CustardTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardTest: XCTestCase {
     func testDecode() {
@@ -87,7 +87,7 @@ final class CustardTest: XCTestCase {
                         longpress_actions: .init(repeat: [.delete(1)]),
                         variations: []
                     )
-                )
+                ),
             ]
 
             var cuneiforms_keys = keys

--- a/AzooKeyCore/Tests/CustardKitTests/CustardVariationKeyDesignTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardVariationKeyDesignTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CustardVariationKeyDesignTest: XCTestCase {
     func testDecode() {
@@ -19,11 +19,11 @@ final class CustardVariationKeyDesignTest: XCTestCase {
 
     func testEncode() {
         do {
-            let target = CustardVariationKeyDesign.init(label: .systemImage("hichhich"))
+            let target = CustardVariationKeyDesign(label: .systemImage("hichhich"))
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
         do {
-            let target = CustardVariationKeyDesign.init(label: .text("椎乃味醂"))
+            let target = CustardVariationKeyDesign(label: .text("椎乃味醂"))
             XCTAssertEqual(target.quickEncodeDecode(), target)
         }
     }

--- a/AzooKeyCore/Tests/CustardKitTests/DecodeCodableActionTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/DecodeCodableActionTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class DecodeCodableActionTest: XCTestCase {
     func testDecodeInput() {
@@ -66,7 +66,7 @@ final class DecodeCodableActionTest: XCTestCase {
                 "天": "地",
                 "海": "山",
                 "正": "負",
-                "嬉": "悲"
+                "嬉": "悲",
             ]))
         }
         do {

--- a/AzooKeyCore/Tests/CustardKitTests/EncodeCodableActionTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/EncodeCodableActionTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 /// Test class for encoding of `CodableActionData`
 /// Make sure that decoding of `CodablaActionData` is successfuly working
@@ -21,7 +21,7 @@ final class EncodeCodableActionTest: XCTestCase {
             "天": "地",
             "海": "山",
             "正": "負",
-            "嬉": "悲"
+            "嬉": "悲",
         ])
         XCTAssertEqual(target.quickEncodeDecode(), target)
     }

--- a/AzooKeyCore/Tests/CustardKitTests/LongpressActionTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/LongpressActionTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class CodableLongpressActionTest: XCTestCase {
     func testDecodeLongpressAction() {
@@ -40,13 +40,13 @@ final class CodableLongpressActionTest: XCTestCase {
     }
 
     func testEncodeLongpressAction() {
-        let target = CodableLongpressActionData.init(start: [.complete, .dismissKeyboard, .moveCursor(-1)], repeat: [.moveCursor(-1)])
+        let target = CodableLongpressActionData(start: [.complete, .dismissKeyboard, .moveCursor(-1)], repeat: [.moveCursor(-1)])
         XCTAssertEqual(target.quickEncodeDecode(), target)
     }
 
     func testStaticValue() {
         let target = CodableLongpressActionData.none
-        XCTAssertEqual(target, CodableLongpressActionData.init(start: [], repeat: []))
+        XCTAssertEqual(target, CodableLongpressActionData(start: [], repeat: []))
     }
 
 }

--- a/AzooKeyCore/Tests/CustardKitTests/TabTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/TabTest.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CustardKit
+import XCTest
 
 final class TabDataTest: XCTestCase {
     func testSystemTab() {

--- a/AzooKeyCore/Tests/CustardKitTests/TestUtility.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/TestUtility.swift
@@ -20,7 +20,7 @@ extension Encodable where Self: Decodable {
     }
 
     public func quickEncodeDecode() -> Self? {
-        return Self.quickDecode(target: self.quickEncode())
+        Self.quickDecode(target: self.quickEncode())
     }
 
     @_disfavoredOverload
@@ -39,7 +39,7 @@ extension Encodable where Self: Decodable {
 
     @_disfavoredOverload
     public func quickEncodeDecode() throws -> Self {
-        return try Self.quickDecode(target: self.quickEncode())
+        try Self.quickDecode(target: self.quickEncode())
     }
 }
 

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -9,8 +9,8 @@
 import AzooKeyUtils
 import Foundation
 import KanaKanjiConverterModule
-import KeyboardViews
 import enum KeyboardExtensionUtils.AnyTextDocumentProxy
+import KeyboardViews
 import SwiftUI
 import SwiftUtils
 

--- a/Keyboard/Display/ReportSubmissionHelper.swift
+++ b/Keyboard/Display/ReportSubmissionHelper.swift
@@ -1,13 +1,13 @@
 import AzooKeyUtils
 import Foundation
+import struct KanaKanjiConverterModule.Candidate
+import enum KanaKanjiConverterModule.ComposingCount
+import struct KanaKanjiConverterModule.ComposingText
+import enum KanaKanjiConverterModule.InputPiece
+import enum KanaKanjiConverterModule.InputStyle
 import KeyboardViews
 import SwiftUtils
 import UIKit
-import enum KanaKanjiConverterModule.InputPiece
-import enum KanaKanjiConverterModule.InputStyle
-import struct KanaKanjiConverterModule.Candidate
-import struct KanaKanjiConverterModule.ComposingText
-import enum KanaKanjiConverterModule.ComposingCount
 
 struct ReportSubmissionHelper {
     @MainActor

--- a/MainApp/App/AppRootView.swift
+++ b/MainApp/App/AppRootView.swift
@@ -10,27 +10,27 @@ struct AppRootView: View {
     var body: some View {
         ZStack {
             AppTabView()
-            .onAppear {
-                onboarding.presentInterruptedTutorialIfNeeded()
-            }
-            .task {
-                await AppLaunchTasks.performMaintenance()
-            }
-            .fullScreenCover(isPresented: $onboarding.isPresented, content: {
-                EnableAzooKeyView(resumeProgress: onboarding.resumeProgress)
-            })
-            .onChange(of: router.selectedTab) { _, selectedTab in
-                if selectedTab == .customization {
-                    customizationWalkthrough.presentIfNeeded()
+                .onAppear {
+                    onboarding.presentInterruptedTutorialIfNeeded()
                 }
-            }
-            .onOpenURL(perform: router.open)
-            .sheet(isPresented: $customizationWalkthrough.isPresented, onDismiss: {
-                customizationWalkthrough.markDone()
-            }, content: {
-                CustomizationWalkthroughView()
-                    .background(Color.background)
-            })
+                .task {
+                    await AppLaunchTasks.performMaintenance()
+                }
+                .fullScreenCover(isPresented: $onboarding.isPresented, content: {
+                    EnableAzooKeyView(resumeProgress: onboarding.resumeProgress)
+                })
+                .onChange(of: router.selectedTab) { _, selectedTab in
+                    if selectedTab == .customization {
+                        customizationWalkthrough.presentIfNeeded()
+                    }
+                }
+                .onOpenURL(perform: router.open)
+                .sheet(isPresented: $customizationWalkthrough.isPresented, onDismiss: {
+                    customizationWalkthrough.markDone()
+                }, content: {
+                    CustomizationWalkthroughView()
+                        .background(Color.background)
+                })
             AppDataUpdateOverlay()
             if router.importedFileURL != nil {
                 URLImportCustardView(

--- a/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
@@ -219,7 +219,7 @@ struct EditingGridFitCustardView: CancelableEditor {
         let keyData: UserMadeKeyData
         if let originalPosition,
            let originalData = editingItem.keys.removeValue(
-               forKey: originalPosition
+            forKey: originalPosition
            ) {
             editingItem.emptyKeys.remove(originalPosition)
             keyData = originalData
@@ -680,7 +680,7 @@ struct EditingGridFitCustardView: CancelableEditor {
                 )
                 guard !editingItem.keys.keys.contains(position),
                       !frames.contains(where: {
-                          gridFramesIntersect($0, frame)
+                        gridFramesIntersect($0, frame)
                       }) else {
                     return
                 }
@@ -934,40 +934,40 @@ private struct GridFitKeyPlacementEditor: View {
                     .fill(Color.secondarySystemBackground)
                 ForEach(Array(occupied.enumerated()), id: \.offset) { _, frame in
                     RoundedRectangle(cornerRadius: 5)
-                    .fill(Color.secondary.opacity(0.35))
-                    .frame(
-                        width: previewKeyWidth(
-                            frame,
-                            unitWidth: unitWidth
-                        ),
-                        height: previewKeyHeight(
-                            frame,
-                            unitHeight: unitHeight
+                        .fill(Color.secondary.opacity(0.35))
+                        .frame(
+                            width: previewKeyWidth(
+                                frame,
+                                unitWidth: unitWidth
+                            ),
+                            height: previewKeyHeight(
+                                frame,
+                                unitHeight: unitHeight
+                            )
                         )
-                    )
-                    .offset(
-                        x: unitWidth * CGFloat(frame.x) + 2,
-                        y: unitHeight * CGFloat(frame.y) + 2
-                    )
+                        .offset(
+                            x: unitWidth * CGFloat(frame.x) + 2,
+                            y: unitHeight * CGFloat(frame.y) + 2
+                        )
                 }
                 if let placement {
                     let frame = placement.frame
                     RoundedRectangle(cornerRadius: 5)
-                    .fill(Color.accentColor.opacity(0.75))
-                    .frame(
-                        width: previewKeyWidth(
-                            frame,
-                            unitWidth: unitWidth
-                        ),
-                        height: previewKeyHeight(
-                            frame,
-                            unitHeight: unitHeight
+                        .fill(Color.accentColor.opacity(0.75))
+                        .frame(
+                            width: previewKeyWidth(
+                                frame,
+                                unitWidth: unitWidth
+                            ),
+                            height: previewKeyHeight(
+                                frame,
+                                unitHeight: unitHeight
+                            )
                         )
-                    )
-                    .offset(
-                        x: unitWidth * CGFloat(frame.x) + 2,
-                        y: unitHeight * CGFloat(frame.y) + 2
-                    )
+                        .offset(
+                            x: unitWidth * CGFloat(frame.x) + 2,
+                            y: unitHeight * CGFloat(frame.y) + 2
+                        )
                 }
             }
             .clipped()

--- a/MainApp/Features/Customization/Custard/Management/ManageCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Management/ManageCustardView.swift
@@ -224,7 +224,6 @@ struct ManageCustardView: View {
         }
     }
 
-
     private var newTabToolBarItem: ToolbarItem<(), some View> {
         ToolbarItem(placement: .topBarTrailing) {
             Menu {

--- a/MainApp/Features/Customization/TabBar/EditingTabBarView.swift
+++ b/MainApp/Features/Customization/TabBar/EditingTabBarView.swift
@@ -11,8 +11,8 @@ import CustardKit
 import Foundation
 import KeyboardViews
 import SwiftUI
-import SwiftUtils
 import SwiftUIUtils
+import SwiftUtils
 
 struct EditingTabBarItem: Identifiable, Equatable {
     let id = UUID()

--- a/MainApp/Features/Onboarding/EnableAzooKeyViewComponent.swift
+++ b/MainApp/Features/Onboarding/EnableAzooKeyViewComponent.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 ensan. All rights reserved.
 //
 
+import struct KeyboardViews.AzooKeyIcon
 import SwiftUI
 import SwiftUIUtils
-import struct KeyboardViews.AzooKeyIcon
 
 struct EnableAzooKeyViewHeader: View {
     private let text: LocalizedStringKey

--- a/MainApp/Features/Onboarding/SharedStore+KeyboardActivation.swift
+++ b/MainApp/Features/Onboarding/SharedStore+KeyboardActivation.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2023 ensan. All rights reserved.
 //
 
+import enum AzooKeyUtils.SharedStore
 import Foundation
 import class UIKit.UITextInputMode
-import enum AzooKeyUtils.SharedStore
 
 extension SharedStore {
     @MainActor static func checkKeyboardActivation() -> Bool {

--- a/MainApp/Features/Settings/Conversion/Learning/LearningTypeSettingView.swift
+++ b/MainApp/Features/Settings/Conversion/Learning/LearningTypeSettingView.swift
@@ -7,8 +7,8 @@
 //
 
 import AzooKeyUtils
-import SwiftUI
 import enum KanaKanjiConverterModule.LearningType
+import SwiftUI
 
 struct LearningTypeSettingView: View {
     @State private var setting: SettingUpdater<LearningTypeSetting>

--- a/MainApp/Features/Settings/Dictionary/UserDictionary/AzooKeyUserDictionary.swift
+++ b/MainApp/Features/Settings/Dictionary/UserDictionary/AzooKeyUserDictionary.swift
@@ -8,11 +8,11 @@
 
 import AzooKeyUtils
 import Foundation
+import struct KanaKanjiConverterModule.Candidate
+import struct KanaKanjiConverterModule.DateTemplateLiteral
+import struct KanaKanjiConverterModule.TemplateData
 import KeyboardViews
 import SwiftUI
-import struct KanaKanjiConverterModule.Candidate
-import struct KanaKanjiConverterModule.TemplateData
-import struct KanaKanjiConverterModule.DateTemplateLiteral
 
 import SwiftUIUtils
 import SwiftUtils

--- a/MainApp/Features/Settings/Keyboard/Layout/KeyboardLayoutSettingItemView.swift
+++ b/MainApp/Features/Settings/Keyboard/Layout/KeyboardLayoutSettingItemView.swift
@@ -107,8 +107,8 @@ struct LanguageLayoutSettingView<SettingKey: LanguageLayoutKeyboardSetting>: Vie
                         sizing: .fitToExtension,
                         defaultTab: tab
                     )
-                        .allowsHitTesting(false)
-                        .disabled(true)
+                    .allowsHitTesting(false)
+                    .disabled(true)
                 }
             } else {
                 VStack {
@@ -118,8 +118,8 @@ struct LanguageLayoutSettingView<SettingKey: LanguageLayoutKeyboardSetting>: Vie
                             sizing: .fitToExtension,
                             defaultTab: tab
                         )
-                            .allowsHitTesting(false)
-                            .disabled(true)
+                        .allowsHitTesting(false)
+                        .disabled(true)
                     }
                     Picker(selection: $selection, label: Text(labelText)) {
                         ForEach(0 ..< types.count, id: \.self) { i in

--- a/MainApp/Features/Theme/ThemeHomeView.swift
+++ b/MainApp/Features/Theme/ThemeHomeView.swift
@@ -157,28 +157,28 @@ struct ThemeHomeView: View {
                             sizing: .fitToExtension,
                             defaultTab: tab
                         )
-                            .disabled(true)
-                            .overlay {
-                                if manager.selectedIndex == index || manager.selectedIndexInDarkMode == index {
-                                    Color.black.opacity(0.3)
-                                }
+                        .disabled(true)
+                        .overlay {
+                            if manager.selectedIndex == index || manager.selectedIndexInDarkMode == index {
+                                Color.black.opacity(0.3)
                             }
-                            .background {
-                                Rectangle()
-                                    .foregroundStyle(.systemGray4)
+                        }
+                        .background {
+                            Rectangle()
+                                .foregroundStyle(.systemGray4)
+                        }
+                        .onTapGesture {
+                            if manager.selectedIndex != index && manager.selectedIndexInDarkMode != index {
+                                self.manager.select(at: index)
                             }
-                            .onTapGesture {
-                                if manager.selectedIndex != index && manager.selectedIndexInDarkMode != index {
-                                    self.manager.select(at: index)
-                                }
+                        }
+                        .overlay(alignment: .bottom) {
+                            if let title = manager.themeTitle(at: index) {
+                                Label(title, systemImage: "photo")
+                                    .labelStyle(LiquidLabelStyle())
+                                    .labelStyle(.titleOnly)
                             }
-                            .overlay(alignment: .bottom) {
-                                if let title = manager.themeTitle(at: index) {
-                                    Label(title, systemImage: "photo")
-                                        .labelStyle(LiquidLabelStyle())
-                                        .labelStyle(.titleOnly)
-                                }
-                            }
+                        }
                         if manager.selectedIndex == manager.selectedIndexInDarkMode,
                            manager.selectedIndex == index {
                             circle(width: 80, systemName: "checkmark", color: .blue)

--- a/MainApp/Features/Tips/Articles/UseContactInfoSettingTipsView.swift
+++ b/MainApp/Features/Tips/Articles/UseContactInfoSettingTipsView.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 DevEn3. All rights reserved.
 //
 
-import SwiftUI
 import class KeyboardViews.SemiStaticStates
+import SwiftUI
 
 struct UseContactInfoSettingTipsView: View {
     var body: some View {

--- a/MainApp/Shared/UI/Components/KeyboardPreview.swift
+++ b/MainApp/Shared/UI/Components/KeyboardPreview.swift
@@ -74,7 +74,7 @@ enum KeyboardPreviewSizing: Equatable {
                 context: context,
                 upsideComponent: nil
             ) * CGFloat(AzooKeySettingProvider.keyboardHeight)
-                + Design.keyboardScreenBottomPadding
+            + Design.keyboardScreenBottomPadding
         )
     }
 


### PR DESCRIPTION
## 概要

- `swiftlint --fix --format`による自動修正をSwiftファイル44件へ適用
- import順、インデント、改行などを現在の`.swiftlint.yml`に合わせて統一
- 動作変更を含まないフォーマット専用PRとして分離

## 対象外

SwiftLint由来ではない以下のローカル差分は、このPRに含めていません。

- `Resources/Localizable.xcstrings`
- `azooKey.xcodeproj/xcshareddata/xcschemes/MainApp.xcscheme`

## 確認

- `swiftlint --no-cache`
  - 既存warning: 54件
  - 重大違反: 0件
- `git diff --cached --check`
