### PR TITLE
feat: v3.1以降の新規ユーザーでQwertyのシフトキーをデフォルト有効化

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AppVersion.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AppVersion.swift
@@ -68,6 +68,7 @@ public struct AppVersion: Codable, Equatable, Comparable, Hashable, LosslessStri
     }
 }
 public extension AppVersion {
+    static let azooKey_v3_1 = AppVersion("3.1")!
     static let azooKey_v3_0_3 = AppVersion("3.0.3")!
     static let azooKey_v3_0_2 = AppVersion("3.0.2")!
     static let azooKey_v3_0_1 = AppVersion("3.0.1")!

--- a/MainApp/App/Launch/AppLaunchTasks.swift
+++ b/MainApp/App/Launch/AppLaunchTasks.swift
@@ -16,6 +16,12 @@ enum AppLaunchTasks {
         if let initialVersion = SharedStore.initialAppVersion, initialVersion > .azooKey_v2_2_2 {
             KeepDeprecatedShiftKeyBehavior.value = false
         }
+
+        if let initialVersion = SharedStore.initialAppVersion,
+           initialVersion >= .azooKey_v3_1,
+           UseShiftKey.get() == nil {
+            UseShiftKey.value = true
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## 概要

v3.1以降にazooKeyの利用を開始したユーザーについて、Qwertyキーボードのシフトキーをデフォルトで有効にします。

## 変更内容

- `AppVersion` にv3.1のバージョン定数を追加
- アプリの初期セットアップ時、以下を両方満たす場合のみ `UseShiftKey.value` を `true` に設定
  - 初回利用バージョンがv3.1以降
  - `use_shift_key` がまだ保存されていない

## 影響

- v3.1以降の新規ユーザーでは、Qwertyキーボードにシフトキーがデフォルトで表示されます
- v3.1より前から利用している既存ユーザーの設定は変更されません
- シフトキーを明示的にオフにしたユーザーの設定も維持されます

## 確認

- iOS Simulator向けMainAppビルド成功
  - `xcodebuild -project azooKey.xcodeproj -scheme MainApp -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/azookey-use-shift-derived CODE_SIGNING_ALLOWED=NO build`
- `git diff --check` 成功