### PR TITLE
fix(dictionary): 絵文字候補のVS16を保持する

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/UserDictionary/UserDictionaryWordFilter.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/UserDictionary/UserDictionaryWordFilter.swift
@@ -1,0 +1,11 @@
+public enum UserDictionaryWordFilter {
+    /// denylistに含まれない場合、Variation Selectorを含む元の表記を返す。
+    public static func filter(_ word: String, denylist: Set<String>) -> String? {
+        // Variation Selectorの有無にかかわらず同じ文字をdenylistで除外する
+        let denylistCheckTarget = String(word.unicodeScalars.filter { $0.value != 0xFE0F })
+        guard denylistCheckTarget.allSatisfy({ !denylist.contains(String($0)) }) else {
+            return nil
+        }
+        return word
+    }
+}

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserDictionaryWordFilterTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserDictionaryWordFilterTests.swift
@@ -1,0 +1,18 @@
+import AzooKeyUtils
+import XCTest
+
+final class UserDictionaryWordFilterTests: XCTestCase {
+    func test_preservesVariationSelector16() {
+        let word = "♨️"
+
+        XCTAssertEqual(UserDictionaryWordFilter.filter(word, denylist: []), word)
+    }
+
+    func test_appliesDenylistWithoutVariationSelector16() {
+        XCTAssertNil(UserDictionaryWordFilter.filter("♨️", denylist: ["♨"]))
+    }
+
+    func test_returnsNonDeniedWord() {
+        XCTAssertEqual(UserDictionaryWordFilter.filter("温泉", denylist: ["♨"]), "温泉")
+    }
+}

--- a/MainApp/Features/Settings/Dictionary/UserDictionary/UserDictionaryUpdater.swift
+++ b/MainApp/Features/Settings/Dictionary/UserDictionary/UserDictionaryUpdater.swift
@@ -149,10 +149,7 @@ struct UserDictionaryUpdater {
                 }
                 let ruby = items[0]
                 let rawWord = items[1]
-                // variation selector を除去
-                let normalizedWord = String(rawWord.unicodeScalars.filter { $0.value != 0xFE0F })
-                // denylist フィルタ
-                guard normalizedWord.allSatisfy({ !self.denylist.contains(String($0)) }) else {
+                guard let storedWord = UserDictionaryWordFilter.filter(rawWord, denylist: self.denylist) else {
                     continue
                 }
 
@@ -161,7 +158,7 @@ struct UserDictionaryUpdater {
                 let mid = Int(items[4]) ?? 0
                 let value = PValue(items[5]) ?? -30.0
                 let entry = DicdataElement(
-                    word: normalizedWord,
+                    word: storedWord,
                     ruby: ruby,
                     lcid: lcid,
                     rcid: rcid,
@@ -169,7 +166,7 @@ struct UserDictionaryUpdater {
                     value: value
                 )
                 // templateが含まれる場合ショートカット扱いする
-                let isShortcut = Candidate.parseTemplate(normalizedWord) != normalizedWord
+                let isShortcut = Candidate.parseTemplate(storedWord) != storedWord
                 if isShortcut {
                     shortcutEntries.append(entry)
                 } else {


### PR DESCRIPTION
## 概要

追加システム辞書などからユーザー辞書形式の辞書を書き出す際、絵文字候補の Variation Selector-16（U+FE0F）が失われる問題を修正します。

## 原因

denylist との照合用に VS16 を除去した文字列を、そのまま `DicdataElement.word` として保存していました。そのため、辞書ソースに VS16 が含まれていても、変換候補ではテキスト表示用の文字列になっていました。

## 変更内容

- denylist 判定を `AzooKeyUtils` の `UserDictionaryWordFilter` へ移動
- denylist 判定時のみ VS16 を除去し、辞書へ保存する表記は元の文字列を保持
- VS16 の保持、VS16 を無視した denylist 判定、通常文字列の通過を確認する単体テストを追加

これにより、絵文字辞書・ユーザー辞書・ホットフィックス辞書由来の候補で VS16 が保持されます。

## 動作確認

- `UserDictionaryWordFilterTests`: 3件成功
- MainApp の iOS Simulator 向けビルド成功
- `AzooKeyUtilsTests` 全体では、本変更と無関係な既存テスト2件が失敗
  - `UserDictionaryMigrationTests.test_migrate_known_single_placeholder_merges_into_date_format`
  - `UserMadeCustardTests.test_defaultQwertySymbolRowsUseEqualKeyWidths`

## 関連 Issue

Closes #739
Related to #737