### PR TITLE
fix(core): AzooKeyUtilsのテスト失敗を解消

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
@@ -165,12 +165,20 @@ private enum DefaultQwertyCustards {
             ? legacyNumberMiddleKeys
             : customKeys.keys
         let middleKeyWidth = 7.0 / Double(middleKeys.count)
-        for (index, key) in middleKeys.enumerated() {
+        let middleKeyGeometry = middleKeys.count == punctuationGeometry.count
+            ? punctuationGeometry
+            : middleKeys.indices.map { index in
+                (
+                    x: 1.5 + Double(index) * middleKeyWidth,
+                    width: middleKeyWidth
+                )
+            }
+        for (key, geometry) in zip(middleKeys, middleKeyGeometry) {
             keys[
                 position(
-                    1.5 + Double(index) * middleKeyWidth,
+                    geometry.x,
                     2,
-                    width: middleKeyWidth
+                    width: geometry.width
                 )
             ] = customInputKey(
                 label: key.name,

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserDictionaryMigrationTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserDictionaryMigrationTests.swift
@@ -24,7 +24,9 @@ final class UserDictionaryMigrationTests: XCTestCase {
         guard let migratedDate = td.literal as? DateTemplateLiteral else {
             XCTFail("Expected DateTemplateLiteral"); return
         }
-        XCTAssertEqual(migratedDate.format, "prefix yyyy/MM/dd suffix")
+        // v3.0.2から、前後の文字列はICUの日付パターンとして解釈されないよう
+        // シングルクォートで囲んで保存している。この保存形式を維持する。
+        XCTAssertEqual(migratedDate.format, "'prefix 'yyyy/MM/dd' suffix'")
     }
 
     func test_migrate_unknown_single_placeholder_skipped() {


### PR DESCRIPTION
## 概要

`AzooKeyUtilsTests`で残っていた2件の失敗を解消します。

- ユーザー辞書の日付テンプレート移行テストを、v3.0.2から使われているICUクォート付き保存形式に合わせる
- 数字QWERTYの中央5キーで、浮動小数点演算による座標のずれをなくす

## 原因

### UserDictionaryMigrationTests

実装は前後のリテラルをICUの日付パターンとして誤解釈されないようシングルクォートで囲んでいましたが、テストの期待値だけがクォートなしになっていました。

### UserMadeCustardTests

中央キーの座標を `1.5 + index * 1.4` で算出していたため、一部の値が `5.7` と厳密には一致せず、辞書キーの検索に失敗していました。

## v3.0.2との互換性

- ユーザー辞書の日付テンプレートの保存形式・移行処理は変更していません
- QWERTYカスタムキーの保存・復元形式は変更していません
- 5キー時の配置のみ、既存の標準座標定数を再利用して安定化しています

## テスト

以下をiOS Simulatorで実行し、26件すべて成功しました。

```sh
xcodebuild -scheme AzooKeyUtils \
  -destination 'platform=iOS Simulator,id=<simulator-id>' \
  -enableCodeCoverage NO \
  -only-testing:AzooKeyUtilsTests test
```