### PR TITLE
fix(custard): 操作不能なキー配置を防止

### DIFF
--- a/AzooKeyCore/Sources/CustardKit/CustardKit.swift
+++ b/AzooKeyCore/Sources/CustardKit/CustardKit.swift
@@ -247,6 +247,15 @@ public struct GridFitPositionSpecifier: Codable, Hashable, Sendable {
     public var width: Double
     public var height: Double
 
+    /// Returns whether this key frame and another frame share a positive-area region.
+    /// Frames that only touch at an edge are not considered intersecting.
+    public func intersects(_ other: Self) -> Bool {
+        self.x < other.x + other.width
+            && other.x < self.x + self.width
+            && self.y < other.y + other.height
+            && other.y < self.y + self.height
+    }
+
     private enum CodingKeys: CodingKey {
         case x, y, width, height
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedKeysView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedKeysView.swift
@@ -1,3 +1,4 @@
+import CustardKit
 import Foundation
 import SwiftUI
 
@@ -7,12 +8,24 @@ public struct UnifiedKeysView<Extension: ApplicationSpecificKeyboardViewExtensio
     private let tabDesign: TabDependentDesign
     @State private var activeSuggestKeys: Set<String> = []
 
-    private static func isWithinBounds(_ position: UnifiedPositionSpecifier, tabDesign: TabDependentDesign) -> Bool {
-        position.x >= 0 && position.y >= 0 && position.x + position.width <= tabDesign.horizontalKeyCount && position.y + position.height <= tabDesign.verticalKeyCount
+    private static func isVisible(_ position: UnifiedPositionSpecifier, tabDesign: TabDependentDesign) -> Bool {
+        GridFitPositionSpecifier(
+            x: Double(position.x),
+            y: Double(position.y),
+            width: Double(position.width),
+            height: Double(position.height)
+        ).intersects(
+            .init(
+                x: 0,
+                y: 0,
+                width: Double(tabDesign.horizontalKeyCount),
+                height: Double(tabDesign.verticalKeyCount)
+            )
+        )
     }
 
     public init(models: [(position: UnifiedPositionSpecifier, model: any UnifiedKeyModelProtocol<Extension>)], tabDesign: TabDependentDesign, @ViewBuilder generator: @escaping (UnifiedGenericKeyView<Extension>, UnifiedPositionSpecifier) -> (Content)) {
-        self.models = models.filter { Self.isWithinBounds($0.position, tabDesign: tabDesign) }
+        self.models = models.filter { Self.isVisible($0.position, tabDesign: tabDesign) }
         self.tabDesign = tabDesign
         self.contentGenerator = generator
     }

--- a/AzooKeyCore/Tests/CustardKitTests/GridFitPositionSpecifierTests.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/GridFitPositionSpecifierTests.swift
@@ -1,0 +1,43 @@
+@testable import CustardKit
+import XCTest
+
+final class GridFitPositionSpecifierTests: XCTestCase {
+    private let bounds = GridFitPositionSpecifier(
+        x: 0,
+        y: 0,
+        width: 5,
+        height: 4
+    )
+
+    func testIntersectsWhenFullyInsideBounds() {
+        XCTAssertTrue(
+            GridFitPositionSpecifier(x: 1, y: 1).intersects(bounds)
+        )
+    }
+
+    func testIntersectsWhenPartiallyOutsideBounds() {
+        XCTAssertTrue(
+            GridFitPositionSpecifier(
+                x: -0.5,
+                y: 3.5,
+                width: 1,
+                height: 1
+            ).intersects(bounds)
+        )
+    }
+
+    func testDoesNotIntersectWhenFullyOutsideBounds() {
+        XCTAssertFalse(
+            GridFitPositionSpecifier(x: 5, y: 0).intersects(bounds)
+        )
+        XCTAssertFalse(
+            GridFitPositionSpecifier(x: -1, y: 0).intersects(bounds)
+        )
+        XCTAssertFalse(
+            GridFitPositionSpecifier(x: 0, y: 4).intersects(bounds)
+        )
+        XCTAssertFalse(
+            GridFitPositionSpecifier(x: 0, y: -1).intersects(bounds)
+        )
+    }
+}

--- a/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
@@ -39,10 +39,7 @@ private func gridFramesIntersect(
     _ lhs: GridFitPositionSpecifier,
     _ rhs: GridFitPositionSpecifier
 ) -> Bool {
-    lhs.x < rhs.x + rhs.width
-        && rhs.x < lhs.x + lhs.width
-        && lhs.y < rhs.y + rhs.height
-        && rhs.y < lhs.y + lhs.height
+    lhs.intersects(rhs)
 }
 
 fileprivate extension Dictionary where Key == KeyPosition, Value == UserMadeKeyData {
@@ -848,6 +845,15 @@ private struct GridFitKeyPlacementEditor: View {
         }
         guard placement.width > 0, placement.height > 0 else {
             return "横幅と縦幅は0より大きくしてください"
+        }
+        let placementBounds = GridFitPositionSpecifier(
+            x: 0,
+            y: 0,
+            width: Double(horizontalCount),
+            height: Double(verticalCount)
+        )
+        guard placement.frame.intersects(placementBounds) else {
+            return "キーの一部が配置範囲に入るようにしてください"
         }
         guard !occupied.contains(where: {
             $0.x == placement.x && $0.y == placement.y


### PR DESCRIPTION
## 概要

カスタムタブの作成画面でキーを配置範囲外へ移動した際、画面から消えたまま内部データに残り、編集・削除できなくなる問題を修正します。

## 原因

配置画面では範囲外の座標を確定できる一方、描画側では配置範囲に完全に収まらないキーを除外していたため、データだけが残る状態になっていました。

## 変更内容

- キーと配置範囲に可視面積があるかを矩形交差判定で共通化
- 一部でも配置範囲に入るキーは描画し、はみ出しを許可
- 完全に配置範囲外となる場合のみ確定不可に変更
- 境界条件の単体テストを追加

## 影響

部分的にはみ出した既存キーは表示・操作できるようになります。完全に範囲外となる新規配置は保存できません。既に保存されている完全な範囲外キーの自動削除は行いません。

## 確認

- [x] CustardKitTests（追加した3件が成功）
- [x] MainApp Release / iOS Simulator ビルド
- [x] SwiftLint